### PR TITLE
Added current directory for some Perl scripts

### DIFF
--- a/testsuite/runtest.pl
+++ b/testsuite/runtest.pl
@@ -25,6 +25,9 @@ $debug_mode     = 0;
 use Getopt::Long;
 #use Unix::PID;
 use Data::Dumper;
+
+# Add root directory
+use lib '.';
 use ompts_parserFunctions;
 
 # Extracting given options

--- a/testsuite/template_parser_c.pl
+++ b/testsuite/template_parser_c.pl
@@ -16,6 +16,8 @@
 
 # Using Getopt::long to extract the programm options
 use Getopt::Long;
+# Add root directory
+use lib '.';
 # Using functions: Set of subroutines to modify the testcode
 use ompts_parserFunctions;
 

--- a/testsuite/template_parser_fortran.pl
+++ b/testsuite/template_parser_fortran.pl
@@ -16,6 +16,8 @@
 
 # Using Getopt::long to extract the programm options
 use Getopt::Long;
+# Add root directory
+use lib '.';
 # Using functions: Set of subroutines to modify the testcode
 use ompts_parserFunctions;
 


### PR DESCRIPTION
New versions of Perl do not include '.' in @INC by default. This patch
adds '.' manually to search for modules.