### PR TITLE
Fix #16: add a dependency for correct parallel compilation

### DIFF
--- a/runtime/src/CMakeLists.txt
+++ b/runtime/src/CMakeLists.txt
@@ -145,6 +145,9 @@ endif()
 libomp_get_ldflags(LIBOMP_CONFIGURED_LDFLAGS)
 
 add_library(omp ${LIBOMP_LIBRARY_KIND} ${LIBOMP_SOURCE_FILES})
+if(${LIBOMP_USE_BUILTIN_ARGOBOTS})
+  add_dependencies(omp libabt)
+endif()
 
 set_target_properties(omp PROPERTIES
   PREFIX "" SUFFIX "" OUTPUT_NAME "${LIBOMP_LIB_FILE}"


### PR DESCRIPTION
This commit solves #16.

The problem happens because libomp was not dependent on the embedded Argobots, while "abt.h" must be created before compiling libomp. 

This commit modifies `runtime/src/CMakeLists.txt` and adds a dependency.

This bug exists in not only 1.0rc, but the previous versions.
I have confirmed that this change does not affect compilations with other configurations (e.g., external Argobots, or Pthreads) 
