### PR TITLE
Fix compilation process of built-in Argobots

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -16,21 +16,21 @@ endif()
 
 if(${LIBOMP_USE_BUILTIN_ARGOBOTS})
   # Use the built-in Argobots
-  set(ABT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/argobots)
+  set(ABT_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/argobots)
   set(ABT_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/argobots)
   set(ABT_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/argobots/install)
-  set(ABT_AUTOGEN ${ABT_DIR}/autogen.sh)
-  set(ABT_CONFIGURE ${ABT_DIR}/configure)
+  set(ABT_AUTOGEN ${ABT_SRC_DIR}/autogen.sh)
+  set(ABT_CONFIGURE ${ABT_SRC_DIR}/configure)
   if ((NOT EXISTS ${ABT_CONFIGURE}) OR (${ABT_AUTOGEN} IS_NEWER_THAN ${ABT_CONFIGURE}))
     execute_process(
       COMMAND ./autogen.sh
-      WORKING_DIRECTORY ${ABT_DIR}
+      WORKING_DIRECTORY ${ABT_SRC_DIR}
     )
   endif()
 
   include(ExternalProject)
   ExternalProject_Add(libabt
-    SOURCE_DIR ${ABT_DIR}
+    SOURCE_DIR ${ABT_SRC_DIR}
     BINARY_DIR ${ABT_BUILD_DIR}
     CONFIGURE_COMMAND ${ABT_CONFIGURE} --prefix=${ABT_INSTALL_DIR} CC=${CMAKE_C_COMPILER}
   )

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 if(${LIBOMP_USE_BUILTIN_ARGOBOTS})
   # Use the built-in Argobots
   set(ABT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/argobots)
+  set(ABT_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/argobots)
   set(ABT_AUTOGEN ${ABT_DIR}/autogen.sh)
   set(ABT_CONFIGURE ${ABT_DIR}/configure)
   if ((NOT EXISTS ${ABT_CONFIGURE}) OR (${ABT_AUTOGEN} IS_NEWER_THAN ${ABT_CONFIGURE}))
@@ -29,6 +30,7 @@ if(${LIBOMP_USE_BUILTIN_ARGOBOTS})
   include(ExternalProject)
   ExternalProject_Add(libabt
     SOURCE_DIR ${ABT_DIR}
+    BINARY_DIR ${ABT_BUILD_DIR}
     CONFIGURE_COMMAND ${ABT_CONFIGURE} --prefix=${CMAKE_INSTALL_PREFIX} CC=${CMAKE_C_COMPILER}
   )
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -18,6 +18,7 @@ if(${LIBOMP_USE_BUILTIN_ARGOBOTS})
   # Use the built-in Argobots
   set(ABT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/argobots)
   set(ABT_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/argobots)
+  set(ABT_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/argobots/install)
   set(ABT_AUTOGEN ${ABT_DIR}/autogen.sh)
   set(ABT_CONFIGURE ${ABT_DIR}/configure)
   if ((NOT EXISTS ${ABT_CONFIGURE}) OR (${ABT_AUTOGEN} IS_NEWER_THAN ${ABT_CONFIGURE}))
@@ -31,10 +32,17 @@ if(${LIBOMP_USE_BUILTIN_ARGOBOTS})
   ExternalProject_Add(libabt
     SOURCE_DIR ${ABT_DIR}
     BINARY_DIR ${ABT_BUILD_DIR}
-    CONFIGURE_COMMAND ${ABT_CONFIGURE} --prefix=${CMAKE_INSTALL_PREFIX} CC=${CMAKE_C_COMPILER}
+    CONFIGURE_COMMAND ${ABT_CONFIGURE} --prefix=${ABT_INSTALL_DIR} CC=${CMAKE_C_COMPILER}
   )
+  # FIXME: pkfconfig is not properly set since the built-in Argobots is
+  # once installed to a different path.  Temporarily pkgconfig is not installed.
+  install(DIRECTORY ${ABT_INSTALL_DIR}/lib
+          DESTINATION ${CMAKE_INSTALL_PREFIX}
+          PATTERN pkgconfig EXCLUDE)
+  install(DIRECTORY ${ABT_INSTALL_DIR}/include
+          DESTINATION ${CMAKE_INSTALL_PREFIX})
 
-  set(LIBOMP_ARGOBOTS_INSTALL_DIR ${CMAKE_INSTALL_PREFIX} PARENT_SCOPE)
+  set(LIBOMP_ARGOBOTS_INSTALL_DIR ${ABT_INSTALL_DIR} PARENT_SCOPE)
 else()
   set(LIBOMP_ARGOBOTS_INSTALL_DIR /usr/local CACHE PATH
     "Install path for Argobots")


### PR DESCRIPTION
Previously there are two issues:
1. Built-in Argobots is compiled in `bolt/external/argobots`, though this should only contain source files. It should be built in the build directory (`CMAKE_CURRENT_BINARY_DIR`, e.g., `bolt/build/external/argobots`)
2. Built-in Argobots is installed to `CMAKE_INSTALL_PREFIX` (e.g., `bolt/install`) without the install process (e.g., without `make install`). It should be only compiled in the compilation phase (`make`), and then installed to `CMAKE_INSTALL_PREFIX` in the installation phase (`make install`).

This patch fixes these issues.

These issues were reported by @Meinersbur. Thank you!

Minor points:
1. test before installation: `LIBOMP_ARGOBOTS_INSTALL_DIR` is properly set to the local installation directory, so the test (`llvm-lit`) works well even before installation.
2. `autogen.sh`: Ideally `autogen.sh` should be executed in another directory so that we can keep  `bolt/external/argobots` clean. However, it is not possible with the current `autogen` mechanism. At present, it is executed in `bolt/external/argobots`.
3. `pkgconfig`: Since built-in Argobots is first installed to the local path (`CMAKE_CURRENT_BINARY_DIR`, e.g., `bolt/build/external/argobots`), the `pkgconfig/argobots.pc` points to this directory, not the final installation path (e.g., `CMAKE_INSTALL_PREFIX`). However, LLVM and its subprojects use `llvm-config` instead of `pkgconfig`, so `pkgconfig` is not necessary for built-in Argobots; currently `pkgconfig` is not installed.
However, This seems controversial (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=897275) If LLVM starts to use `pkgconfig`, this problem should be fixed.
