### PR TITLE
Fix flag management for tasking

### DIFF
--- a/runtime/src/kmp.h
+++ b/runtime/src/kmp.h
@@ -3711,7 +3711,8 @@ extern void __kmp_abt_set_self_info(kmp_info_t *th);
 extern kmp_info_t *__kmp_abt_get_self_info(void);
 extern void __kmp_abt_release_info(kmp_info_t *th);
 extern void __kmp_abt_acquire_info_for_task(kmp_info_t *th,
-                                            kmp_taskdata_t *taskdata);
+                                            kmp_taskdata_t *taskdata,
+                                            const kmp_team_t *match_team);
 #endif
 
 /* ------------------------------------------------------------------------ */

--- a/runtime/src/kmp_barrier.cpp
+++ b/runtime/src/kmp_barrier.cpp
@@ -2052,7 +2052,7 @@ int __kmp_barrier(enum barrier_type bt, int gtid, int is_split,
       ret = ABT_barrier_wait(team->t.t_team_bar);
       KMP_DEBUG_ASSERT(ret == ABT_SUCCESS);
     }
-    __kmp_abt_acquire_info_for_task(this_thr, taskdata);
+    __kmp_abt_acquire_info_for_task(this_thr, taskdata, team);
   } else { // Team is serialized.
     status = 0;
   }

--- a/runtime/src/kmp_runtime.cpp
+++ b/runtime/src/kmp_runtime.cpp
@@ -7459,7 +7459,7 @@ void __kmp_internal_join(ident_t *id, int gtid, kmp_team_t *team) {
       KA_TRACE(20, ("__kmp_internal_join: after __kmp_join_worker:"
                     " T#%d joined T#%d\n", gtid, __kmp_gtid_from_tid(f, team)));
     }
-    __kmp_abt_acquire_info_for_task(this_thr, taskdata);
+    __kmp_abt_acquire_info_for_task(this_thr, taskdata, team);
   }
 #else // KMP_USE_ABT
   __kmp_join_barrier(gtid); /* wait for everyone */

--- a/runtime/src/kmp_tasking.cpp
+++ b/runtime/src/kmp_tasking.cpp
@@ -2004,14 +2004,16 @@ kmp_int32 __kmpc_omp_taskyield(ident_t *loc_ref, kmp_int32 gtid, int end_part) {
   thread = __kmp_threads[gtid];
   taskdata = thread->th.th_current_task;
   // Let others, e.g., tasks, can use this kmp_info.
+  // Get the associated team before releasing the ownership of th.
+  kmp_team_t *team = thread->th.th_team;
   __kmp_abt_release_info(thread);
   // In a taskyield directive we just do it... yield
   __kmp_yield(1);
   if (taskdata->td_flags.tiedness) {
     // Obtain kmp_info to continue the original task.
-    __kmp_abt_acquire_info_for_task(thread, taskdata);
+    __kmp_abt_acquire_info_for_task(thread, taskdata, team);
   } else {
-    thread = __kmp_abt_bind_task_to_thread(thread->th.th_team, taskdata);
+    thread = __kmp_abt_bind_task_to_thread(team, taskdata);
   }
 
 #else // KMP_USE_ABT

--- a/runtime/src/z_Linux_util.cpp
+++ b/runtime/src/z_Linux_util.cpp
@@ -653,7 +653,6 @@ static void __kmp_abt_launch_worker(void *thr) {
   KA_TRACE(10, ("__kmp_abt_launch_worker: T#%d done\n", gtid));
 
   __kmp_abt_wait_child_tasks(this_thr, FALSE);
-  this_thr->th.th_task_team = NULL;
 
   /* Below is for the implicit task */
   kmp_taskdata_t *td = this_thr->th.th_current_task;

--- a/runtime/src/z_Linux_util.cpp
+++ b/runtime/src/z_Linux_util.cpp
@@ -3604,6 +3604,12 @@ static void __kmp_abt_execute_task(void *arg) {
   KA_TRACE(20, ("__kmp_abt_execute_task: T#%d before executing task %p.\n",
                 gtid, task));
 
+  // See __kmp_task_start
+  taskdata->td_flags.started = 1;
+  taskdata->td_flags.executing = 1;
+  KMP_DEBUG_ASSERT(taskdata->td_flags.complete == 0);
+  KMP_DEBUG_ASSERT(taskdata->td_flags.freed == 0);
+
   // Run __kmp_invoke_task to handle internal counters correctly.
 #ifdef KMP_GOMP_COMPAT
   if (taskdata->td_flags.native) {
@@ -3619,6 +3625,14 @@ static void __kmp_abt_execute_task(void *arg) {
     // may have been changed.
     th = __kmp_abt_get_self_info();
   }
+
+  // See __kmp_task_finish
+  // KMP_DEBUG_ASSERT(taskdata->td_flags.executing == 0);
+  taskdata->td_flags.executing = 0;
+  KMP_DEBUG_ASSERT(taskdata->td_flags.complete == 0);
+  taskdata->td_flags.complete = 1; // mark the task as completed
+  // KMP_DEBUG_ASSERT(taskdata->td_flags.started == 1);
+  // KMP_DEBUG_ASSERT(taskdata->td_flags.freed == 0);
 
   // Free this task.
   __kmp_abt_free_task(th, taskdata);

--- a/runtime/test/misc_bugs/for-task-for-task.c
+++ b/runtime/test/misc_bugs/for-task-for-task.c
@@ -1,0 +1,76 @@
+// RUN: %libomp-compile-and-run
+#include <stdio.h>
+#include <math.h>
+#include "omp_testsuite.h"
+
+#define NUM_OUTER_THREADS 16
+#define NUM_INNER_THREADS 16
+#define SMALL_LOOPCOUNT   64
+
+/*! Utility function to spend some time in a loop */
+static void do_some_work (void) {
+  int i;
+  double sum = 0;
+  for(i = 0; i < 1000; i++) {
+    sum += sqrt(i);
+  }
+}
+
+int test_omp_parallel_for_task_for_task() {
+  int vals[SMALL_LOOPCOUNT];
+  int i;
+  for (i = 0; i < SMALL_LOOPCOUNT; i++) {
+    vals[i] = 0;
+  }
+  #pragma omp parallel firstprivate(vals) num_threads(NUM_OUTER_THREADS)
+  #pragma omp master
+  {
+    for (i = 1; i <= SMALL_LOOPCOUNT; i++) {
+      #pragma omp task firstprivate(i) firstprivate(vals)
+      {
+        #pragma omp parallel num_threads(NUM_INNER_THREADS) firstprivate(i)
+        #pragma omp master
+        {
+          int j;
+          for (j = 1; j <= SMALL_LOOPCOUNT; j++) {
+            #pragma omp task firstprivate(i)
+            {
+              int k;
+              do_some_work();
+              for (k = 0; k < j % 4; k++) {
+                #pragma omp taskyield
+              }
+              #pragma omp atomic
+              vals[i] += j;
+            }
+          }
+        }
+        {
+          int j;
+          for (j = 0; j < i % 5; j++) {
+            #pragma omp taskyield
+          }
+        }
+      }
+    }
+  }
+  int num_failed = 0;
+  int known_sum = SMALL_LOOPCOUNT * (SMALL_LOOPCOUNT + 1) / 2;
+  for (i = 0; i < SMALL_LOOPCOUNT; i++) {
+    if (vals[i] != known_sum)
+      num_failed++;
+  }
+  return num_failed ? 1 : 0;
+}
+
+int main() {
+  int i;
+  int num_failed = 0;
+
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_omp_parallel_for_task_for_task()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/misc_bugs/for-task-for.c
+++ b/runtime/test/misc_bugs/for-task-for.c
@@ -1,0 +1,69 @@
+// RUN: %libomp-compile-and-run
+#include <stdio.h>
+#include <math.h>
+#include "omp_testsuite.h"
+
+#define NUM_OUTER_THREADS 16
+#define NUM_INNER_THREADS 16
+#define SMALL_LOOPCOUNT   64
+
+/*! Utility function to spend some time in a loop */
+static void do_some_work (void) {
+  int i;
+  double sum = 0;
+  for(i = 0; i < 1000; i++) {
+    sum += sqrt(i);
+  }
+}
+
+int test_omp_parallel_for_task_for() {
+  int vals[SMALL_LOOPCOUNT];
+  int i;
+  for (i = 0; i < SMALL_LOOPCOUNT; i++) {
+    vals[i] = 0;
+  }
+  #pragma omp parallel firstprivate(vals) num_threads(NUM_OUTER_THREADS)
+  #pragma omp master
+  {
+    for (i = 1; i <= SMALL_LOOPCOUNT; i++) {
+      #pragma omp task firstprivate(i) firstprivate(vals)
+      {
+        int local_sum = 0;
+        int j;
+        #pragma omp parallel for reduction(+:local_sum) \
+                num_threads(NUM_INNER_THREADS)
+        for (j = 1; j <= SMALL_LOOPCOUNT; j++) {
+          int k;
+          do_some_work();
+          for (k = 0; k < j % 4; k++) {
+            #pragma omp taskyield
+          }
+          local_sum += j;
+        }
+        for (j = 0; j < i % 5; j++) {
+          #pragma omp taskyield
+        }
+        vals[i] = local_sum;
+      }
+    }
+  }
+  int num_failed = 0;
+  int known_sum = SMALL_LOOPCOUNT * (SMALL_LOOPCOUNT + 1) / 2;
+  for (i = 0; i < SMALL_LOOPCOUNT; i++) {
+    if (vals[i] != known_sum)
+      num_failed++;
+  }
+  return num_failed ? 1 : 0;
+}
+
+int main() {
+  int i;
+  int num_failed = 0;
+
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_omp_parallel_for_task_for()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}


### PR DESCRIPTION
This PR fixes several bugs for tasking (especially caused by careless flag management).
To check the correctness of the changes, this PR also contains tests that require these changes (`for-task-for` and `for-task-for-task`).