### PR TITLE
Remove fork-join lock in the critical path

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -140,6 +140,8 @@ set(LIBOMP_HWLOC_INSTALL_DIR /usr/local CACHE PATH
 # Argobots-support
 set(LIBOMP_USE_ARGOBOTS FALSE CACHE BOOL
   "Use Argobots (http://www.argobots.org) as threading model?")
+set(LIBOMP_REMOVE_FORKJOIN_LOCK FALSE CACHE BOOL
+  "Remove FORK_JOIN_LOCK (experimental)")
 if(LIBOMP_USE_ARGOBOTS)
   set(KMP_USE_ABT 1)
   set(KMP_ABT_USE_SELF_INFO 1)

--- a/runtime/src/kmp.h
+++ b/runtime/src/kmp.h
@@ -896,7 +896,8 @@ extern void __kmp_fini_memkind();
 #define KMP_MIN_NTH 1
 
 #ifndef KMP_MAX_NTH
-#if defined(PTHREAD_THREADS_MAX) && PTHREAD_THREADS_MAX < INT_MAX
+#if defined(PTHREAD_THREADS_MAX) && PTHREAD_THREADS_MAX < INT_MAX \
+    && !KMP_USE_ABT
 #define KMP_MAX_NTH PTHREAD_THREADS_MAX
 #else
 #define KMP_MAX_NTH INT_MAX

--- a/runtime/src/kmp.h
+++ b/runtime/src/kmp.h
@@ -2832,6 +2832,9 @@ typedef struct kmp_base_root {
   kmp_lock_t r_begin_lock;
   volatile int r_begin;
   int r_blocktime; /* blocktime for this root and descendants */
+#if KMP_REMOVE_FORKJOIN_LOCK
+  // r_cg_nthreads must be updated atomically.
+#endif
   int r_cg_nthreads; // count of active threads in a contention group
 } kmp_base_root_t;
 
@@ -3017,6 +3020,10 @@ extern int __kmp_max_nth;
 // maximum total number of concurrently-existing threads in a contention group
 extern int __kmp_cg_max_nth;
 extern int __kmp_teams_max_nth; // max threads used in a teams construct
+#if KMP_REMOVE_FORKJOIN_LOCK
+/* __kmp_threads_capacity must be protected by __kmp_threads_lock */
+/* write: lock  read: anytime */
+#endif
 extern int __kmp_threads_capacity; /* capacity of the arrays __kmp_threads and
                                       __kmp_root */
 extern int __kmp_dflt_team_nth; /* default number of threads in a parallel
@@ -3129,6 +3136,7 @@ extern int __kmp_omp_cancellation; /* TRUE or FALSE */
 
 /* ------------------------------------------------------------------------- */
 
+#if !KMP_REMOVE_FORKJOIN_LOCK
 /* the following are protected by the fork/join lock */
 /* write: lock  read: anytime */
 extern kmp_info_t **__kmp_threads; /* Descriptors for the threads */
@@ -3147,6 +3155,30 @@ extern std::atomic<int> __kmp_thread_pool_active_nth;
 
 extern kmp_root_t **__kmp_root; /* root of thread hierarchy */
 /* end data protected by fork/join lock */
+#else
+/* write: lock  read: anytime */
+extern kmp_info_t **__kmp_threads; /* Descriptors for the threads */
+extern kmp_bootstrap_lock_t __kmp_threads_lock;
+/* read/write: lock */
+extern volatile kmp_team_t *__kmp_team_pool;
+extern kmp_bootstrap_lock_t __kmp_team_pool_lock;
+/* read/write: lock */
+extern volatile kmp_info_t *__kmp_thread_pool;
+extern kmp_info_t *__kmp_thread_pool_insert_pt;
+extern kmp_bootstrap_lock_t __kmp_thread_pool_lock;
+
+// Must be updated atomically
+// total num threads reachable from some root thread including all root threads
+extern volatile int __kmp_nth;
+/* total number of threads reachable from some root thread including all root
+   threads, and those in the thread pool */
+extern volatile int __kmp_all_nth;
+extern int __kmp_thread_pool_nth;
+extern std::atomic<int> __kmp_thread_pool_active_nth;
+
+extern kmp_root_t **__kmp_root; /* root of thread hierarchy */
+#endif
+
 /* ------------------------------------------------------------------------- */
 
 #define __kmp_get_gtid() __kmp_get_global_thread_id()

--- a/runtime/src/kmp_config.h.cmake
+++ b/runtime/src/kmp_config.h.cmake
@@ -80,6 +80,9 @@
 #cmakedefine01 LIBOMP_USE_ARGOBOTS
 #define KMP_USE_ABT LIBOMP_USE_ARGOBOTS
 
+#cmakedefine01 LIBOMP_REMOVE_FORKJOIN_LOCK
+#define KMP_REMOVE_FORKJOIN_LOCK LIBOMP_REMOVE_FORKJOIN_LOCK
+
 // Configured cache line based on architecture
 #if KMP_ARCH_PPC64
 # define CACHE_LINE 128

--- a/runtime/src/kmp_global.cpp
+++ b/runtime/src/kmp_global.cpp
@@ -423,6 +423,9 @@ kmp_int32 __kmp_yield_off_count =
    of declaration is not necessarily correlated to storage order. To fix this,
    all the important globals must be put in a big structure instead. */
 KMP_ALIGN_CACHE
+#if KMP_REMOVE_FORKJOIN_LOCK
+kmp_bootstrap_lock_t __kmp_threads_lock;
+#endif
 kmp_info_t **__kmp_threads = NULL;
 kmp_root_t **__kmp_root = NULL;
 
@@ -431,7 +434,17 @@ KMP_ALIGN_CACHE
 volatile int __kmp_nth = 0;
 volatile int __kmp_all_nth = 0;
 int __kmp_thread_pool_nth = 0;
+
+#if KMP_REMOVE_FORKJOIN_LOCK
+KMP_ALIGN_CACHE
+kmp_bootstrap_lock_t __kmp_thread_pool_lock;
+#endif
 volatile kmp_info_t *__kmp_thread_pool = NULL;
+
+#if KMP_REMOVE_FORKJOIN_LOCK
+KMP_ALIGN_CACHE
+kmp_bootstrap_lock_t __kmp_team_pool_lock;
+#endif
 volatile kmp_team_t *__kmp_team_pool = NULL;
 
 KMP_ALIGN_CACHE

--- a/runtime/src/kmp_settings.cpp
+++ b/runtime/src/kmp_settings.cpp
@@ -485,10 +485,10 @@ int __kmp_initial_threads_capacity(int req_nproc) {
 
   /* MIN( MAX( 32, 4 * $OMP_NUM_THREADS, 4 * omp_get_num_procs() ),
    * __kmp_max_nth) */
-  if (nth < (4 * req_nproc))
-    nth = (4 * req_nproc);
-  if (nth < (4 * __kmp_xproc))
-    nth = (4 * __kmp_xproc);
+  if (nth < (512 * req_nproc))
+    nth = (512 * req_nproc);
+  if (nth < (512 * __kmp_xproc))
+    nth = (512 * __kmp_xproc);
 
   if (nth > __kmp_max_nth)
     nth = __kmp_max_nth;


### PR DESCRIPTION
This PR removes `__kmp_forkjoin_lock` in the critical path of nested parallel regions when the nested hot team is enabled.  This is necessary to leverage the lightweight ULTs.

This configuration is disabled by default; it can be enabled by setting `LIBOMP_REMOVE_FORKJOIN_LOCK` at configuration time.