### PR TITLE
Implement divide-and-conquer thread fork-join

### DIFF
--- a/runtime/src/kmp.h
+++ b/runtime/src/kmp.h
@@ -2546,6 +2546,10 @@ typedef struct KMP_ALIGN_CACHE kmp_base_info {
   int th_prev_level; /* previous level for affinity format */
   int th_prev_num_threads; /* previous num_threads for affinity format */
 #endif
+#if KMP_USE_ABT
+  // For N-way thread creation.
+  int th_creation_group_end_tid;
+#endif /* KMP_USE_ABT */
 #if USE_ITT_BUILD
   kmp_uint64 th_bar_arrive_time; /* arrival to barrier timestamp */
   kmp_uint64 th_bar_min_time; /* minimum arrival time at the barrier */

--- a/runtime/src/kmp.h
+++ b/runtime/src/kmp.h
@@ -1850,11 +1850,7 @@ typedef enum kmp_bar_pat { /* Barrier communication patterns */
                            bp_last_bar /* Placeholder to mark the end */
 } kmp_bar_pat_e;
 
-#if KMP_USE_ABT
-/* BOLT does not use KMP barrier, so we need to copy icvs in a naive way. */
-#else
 #define KMP_BARRIER_ICV_PUSH 1
-#endif
 
 /* Record for holding the values of the internal controls stack records */
 typedef struct kmp_internal_control {
@@ -2756,6 +2752,10 @@ typedef struct KMP_ALIGN_CACHE kmp_base_team {
 // omp_set_num_threads() call
 #if OMP_50_ENABLED
   void *const *t_def_allocator; /* per implicit task default allocator */
+#endif
+#if KMP_USE_ABT && KMP_BARRIER_ICV_PUSH
+  KMP_ALIGN_CACHE
+  kmp_internal_control_t t_master_icvs; // master's icvs
 #endif
 
 // Read/write by workers as well

--- a/runtime/src/kmp_abt.h
+++ b/runtime/src/kmp_abt.h
@@ -21,6 +21,9 @@
 #define ABT_USE_PRIVATE_POOLS 1
 #define ABT_USE_SCHED_SLEEP 0
 
+#define KMP_ABT_FORK_NUM_WAYS_DEFAULT 2
+#define KMP_ABT_FORK_CUTOFF_DEFAULT (1 << 20)
+
 // ES-local data.
 typedef struct kmp_abt_local {
   /* ------------------------------------------------------------------------ */
@@ -40,6 +43,8 @@ typedef struct kmp_abt_global {
   /* ------------------------------------------------------------------------ */
   // Mostly read only
   int num_xstreams;
+  int fork_num_ways;
+  int fork_cutoff;
 
   // ES-local data.
   kmp_abt_local *locals;

--- a/runtime/src/kmp_runtime.cpp
+++ b/runtime/src/kmp_runtime.cpp
@@ -4614,6 +4614,7 @@ kmp_info_t *__kmp_allocate_thread(kmp_root_t *root, kmp_team_t *team,
   // We don't fork the new work thread (will do it later) but set gtid.
   new_thr->th.th_info.ds.ds_thread = ABT_THREAD_NULL;
   new_thr->th.th_info.ds.ds_gtid = new_gtid;
+  new_thr->th.th_creation_group_end_tid = -1;
 
 #else // KMP_USE_ABT
 


### PR DESCRIPTION
Recursive divide-and-conquer thread fork-join is more efficient than the naive sequential one in BOLT.  This patch implements recursive algorithms for fork-join.

Note that supporting `KMP_BARRIER_ICV_PUSH` is necessary to parallelize the ICV copy; otherwise all ICV copies are done by the master thread.