### PR TITLE
[BOLT] remove r_in_parallel

### DIFF
--- a/runtime/src/kmp.h
+++ b/runtime/src/kmp.h
@@ -2829,15 +2829,11 @@ typedef union KMP_ALIGN_CACHE kmp_global {
 } kmp_global_t;
 
 typedef struct kmp_base_root {
-  // TODO: GEH - combine r_active with r_in_parallel then r_active ==
-  // (r_in_parallel>= 0)
   // TODO: GEH - then replace r_active with t_active_levels if we can to reduce
   // the synch overhead or keeping r_active
   volatile int r_active; /* TRUE if some region in a nest has > 1 thread */
   // GEH: This is misnamed, should be r_in_parallel
   volatile int r_nested; // TODO: GEH - This is unused, just remove it entirely.
-  // keeps a count of active parallel regions per root
-  std::atomic<int> r_in_parallel;
   // GEH: This is misnamed, should be r_active_levels
   kmp_team_t *r_root_team;
   kmp_team_t *r_hot_team;

--- a/runtime/src/kmp_ftn_entry.h
+++ b/runtime/src/kmp_ftn_entry.h
@@ -658,7 +658,7 @@ int FTN_STDCALL KMP_EXPAND_NAME(FTN_IN_PARALLEL)(void) {
     return (th->th.th_team->t.t_active_level ? 1 : 0);
   } else
 #endif /* OMP_40_ENABLED */
-    return (th->th.th_root->r.r_in_parallel ? FTN_TRUE : FTN_FALSE);
+    return (th->th.th_root->r.r_active ? FTN_TRUE : FTN_FALSE);
 #endif
 }
 


### PR DESCRIPTION
As commented in the source code, `r_active` can replace `r_in_parallel`.  This patch simply removes `r_in_parallel` from BOLT.