### PR TITLE
Disable itt notify

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ assumed to be non-existent or empty.
           -DOPENMP_TEST_C_COMPILER=<C compiler for testing> \
           -DOPENMP_TEST_CXX_COMPILER=<C++ compiler for testing> \
           -DCMAKE_BUILD_TYPE=Release \
-          -DLIBOMP_USE_ITT_NOTIFY=off \
           -DLIBOMP_USE_ARGOBOTS=on \
           |& tee c.txt
 
@@ -94,7 +93,6 @@ assumed to be non-existent or empty.
           -DOPENMP_TEST_C_COMPILER=<C compiler for testing> \
           -DOPENMP_TEST_CXX_COMPILER=<C++ compiler for testing> \
           -DCMAKE_BUILD_TYPE=Release \
-          -DLIBOMP_USE_ITT_NOTIFY=off \
           -DLIBOMP_USE_ARGOBOTS=on \
           2>&1 | tee c.txt
 
@@ -109,7 +107,6 @@ assumed to be non-existent or empty.
           -DOPENMP_TEST_C_COMPILER=<C compiler for testing> \
           -DOPENMP_TEST_CXX_COMPILER=<C++ compiler for testing> \
           -DCMAKE_BUILD_TYPE=Release \
-          -DLIBOMP_USE_ITT_NOTIFY=off \
           -DLIBOMP_USE_ARGOBOTS=on \
           -DLIBOMP_ARGOBOTS_INSTALL_DIR=/home/USERNAME/argobots-install \
           |& tee c.txt
@@ -123,7 +120,6 @@ assumed to be non-existent or empty.
           -DOPENMP_TEST_C_COMPILER=<C compiler for testing> \
           -DOPENMP_TEST_CXX_COMPILER=<C++ compiler for testing> \
           -DCMAKE_BUILD_TYPE=Release \
-          -DLIBOMP_USE_ITT_NOTIFY=off \
           -DLIBOMP_USE_ARGOBOTS=on \
           -DLIBOMP_ARGOBOTS_INSTALL_DIR=/home/USERNAME/argobots-install \
           2>&1 | tee c.txt

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -197,6 +197,11 @@ endif()
 set(LIBOMP_USE_ITT_NOTIFY TRUE CACHE BOOL
   "Enable ITT notify?")
 
+if(LIBOMP_USE_ARGOBOTS)
+  # BOLT does not support it.
+  set(LIBOMP_USE_ITT_NOTIFY FALSE)
+endif()
+
 # normal, profile, stubs library.
 set(NORMAL_LIBRARY FALSE)
 set(STUBS_LIBRARY FALSE)


### PR DESCRIPTION
This issue fixes #46. BOLT does not support ITT notify interface, so this PR disables it by default.

Previously, we ask users to explicitly turn it off by setting `-DLIBOMP_USE_ITT_NOTIFY=off` in `README.md`, but we remove these lines since it becomes unnecessary.
