### PR TITLE
Run git submodule if built-in Argobots is not found

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -15,6 +15,25 @@ else()
 endif()
 
 if(${LIBOMP_USE_BUILTIN_ARGOBOTS})
+  # Check if the built-in Argobots exists.
+  if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/argobots/configure.ac")
+    if (EXISTS "${PROJECT_SOURCE_DIR}/.git")
+      message(STATUS "Running `git submodule update --init`")
+      execute_process(COMMAND git submodule update --init
+                      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+                      RESULT_VARIABLE GIT_SUBMOD_RESULT)
+      if (NOT GIT_SUBMOD_RESULT EQUAL "0")
+        message(STATUS "git submodule update --init failed with `${GIT_SUBMOD_RESULT}`. ")
+      else()
+        message(STATUS "Running `git submodule update --init` - Success")
+      endif()
+    endif()
+    if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/argobots/configure.ac")
+        message(FATAL_ERROR "The built-in Argobots is not found. "
+                            "Please run `git submodule update --init` if you get BOLT via GitHub, or "
+                            "download Argobots manually and place it at `external/argobots`.")
+    endif()
+  endif()
   # Use the built-in Argobots
   set(ABT_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/argobots)
   set(ABT_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/argobots)


### PR DESCRIPTION
As pointed out by @devreal in #59, the current CMake is unfriendly if one forgets to run `git submit update --init`. This PR fixes it.

Specifically, it first tries to `git submodule update --init` and if it fails, prints an error message to encourage a user to check it:
```sh
if [ (we use built-in Argobots) && ! -f bolt/external/argobots/configure.ac ]; then
  # not downloaded. Let's do git submodule instead of a user.
  git submodule update --init
  if [ (git submodule failed) ]; then
    # Maybe the running machine is not connected to the internet connection.
    error("Please do it manually.")
  fi
fi
```
