### PR TITLE
Add a script for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+language: c
+
+dist: bionic
+
+os:
+  - linux
+  - osx
+
+env:
+  - USE_ARGOBOTS=TRUE
+  - USE_ARGOBOTS=FALSE
+
+script:
+  - mkdir build && cd build
+  - cmake ../ -DLIBOMP_USE_ARGOBOTS=${USE_ARGOBOTS}
+  - make -j 2


### PR DESCRIPTION
BOLT tests take quite long time. Though some tests in BOLT are unstable and thus might be ignored sometimes, at least, success of compilation should be guaranteed before being merged to the master branch.

This new Travis CI script checks if the PR can be compiled without an error.