### PR TITLE
Mark target_depend_nowait.cpp as supported.

### DIFF
--- a/libomptarget/test/offloading/target_depend_nowait.cpp
+++ b/libomptarget/test/offloading/target_depend_nowait.cpp
@@ -2,7 +2,6 @@
 // RUN: %libomptarget-compilexx-run-and-check-powerpc64-ibm-linux-gnu
 // RUN: %libomptarget-compilexx-run-and-check-powerpc64le-ibm-linux-gnu
 // RUN: %libomptarget-compilexx-run-and-check-x86_64-pc-linux-gnu
-// REQUIRES: !abt
 
 #include <omp.h>
 #include <stdio.h>


### PR DESCRIPTION
Now BOLT supports task depend.  This patch marks `target_depend_nowait.cpp` as supported.

Note that CI tests BOLT + `libomptarget/test` on a CPU device in order to check the very basic  offloading support. Since currently libomptarget only supports newer Clang (>=6.0.0), this test is only available for Clang configurations.