### PR TITLE
Fix compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ env:
 
 script:
   - mkdir build && cd build
-  - cmake ../ -DLIBOMP_USE_ARGOBOTS=${USE_ARGOBOTS}
+  - cmake ../ -DLIBOMP_USE_ARGOBOTS=${USE_ARGOBOTS} -DOPENMP_ENABLE_WERROR=TRUE
   - make -j 2

--- a/runtime/src/kmp_barrier.cpp
+++ b/runtime/src/kmp_barrier.cpp
@@ -2143,7 +2143,6 @@ int __kmp_barrier(enum barrier_type bt, int gtid, int is_split,
   kmp_info_t *this_thr = __kmp_threads[gtid];
   kmp_team_t *team = this_thr->th.th_team;
   int status = 0;
-  ident_t *loc = this_thr->th.th_ident;
   int ret;
   KA_TRACE(15, ("__kmp_barrier: T#%d(%d:%d) has arrived\n",
                 gtid, __kmp_team_from_gtid(gtid)->t.t_id,
@@ -2174,13 +2173,13 @@ int __kmp_barrier(enum barrier_type bt, int gtid, int is_split,
 }
 
 void __kmp_end_split_barrier(enum barrier_type bt, int gtid) {
-  int tid = __kmp_tid_from_gtid(gtid);
   kmp_info_t *this_thr = __kmp_threads[gtid];
   kmp_team_t *team = this_thr->th.th_team;
   if (!team->t.t_serialized) {
     if (KMP_MASTER_GTID(gtid)) {
       int ret = ABT_barrier_wait(team->t.t_team_bar);
       KMP_DEBUG_ASSERT(ret == ABT_SUCCESS);
+      (void)ret;
     }
   }
 }

--- a/runtime/src/kmp_config.h.cmake
+++ b/runtime/src/kmp_config.h.cmake
@@ -98,7 +98,7 @@
 #  define USE_ITT_BUILD 0
 #endif
 #define INTEL_ITTNOTIFY_PREFIX __kmp_itt_
-#if ! KMP_MIC
+#if ! KMP_MIC && ! KMP_USE_ABT
 # define USE_LOAD_BALANCE 1
 #endif
 #if ! (KMP_OS_WINDOWS || KMP_OS_DARWIN)

--- a/runtime/src/kmp_lock.cpp
+++ b/runtime/src/kmp_lock.cpp
@@ -47,9 +47,10 @@ void __kmp_validate_locks(void) {
 
 // kmp_base_xxx_lock_t must be larger than 64 bytes to avoid unintentional
 // inlining (See comments by grepping "__kmp_base_user_lock_size".)
+#define KMP_LOCK_STATIC static inline __attribute__((unused))
 #define KMP_DEFINE_LOCKS(locktype)                                             \
 typedef struct { char _[64]; } kmp_base_ ## locktype ## _lock_t;               \
-static inline int __kmp_is_ ## locktype ## _lock_initialized                   \
+KMP_LOCK_STATIC int __kmp_is_ ## locktype ## _lock_initialized                 \
              (kmp_ ## locktype ## _lock_t *lck) {                              \
   return lck == lck->initialized;                                              \
 }                                                                              \
@@ -92,23 +93,23 @@ void __kmp_destroy_ ## locktype ## _lock                                       \
        (kmp_ ## locktype ## _lock_t *lck) {                                    \
   lck->initialized = NULL;                                                     \
 }                                                                              \
-static inline int __kmp_acquire_ ## locktype ## _lock_with_checks              \
+KMP_LOCK_STATIC int __kmp_acquire_ ## locktype ## _lock_with_checks            \
              (kmp_ ## locktype ## _lock_t *lck, kmp_int32 gtid) {              \
   return __kmp_acquire_ ## locktype ## _lock(lck, gtid);                       \
 }                                                                              \
-static inline int __kmp_test_ ## locktype ## _lock_with_checks                 \
+KMP_LOCK_STATIC int __kmp_test_ ## locktype ## _lock_with_checks               \
              (kmp_ ## locktype ## _lock_t *lck, kmp_int32 gtid) {              \
   return __kmp_test_ ## locktype ## _lock(lck, gtid);                          \
 }                                                                              \
-static inline int __kmp_release_ ## locktype ## _lock_with_checks              \
+KMP_LOCK_STATIC int __kmp_release_ ## locktype ## _lock_with_checks            \
              (kmp_ ## locktype ## _lock_t *lck, kmp_int32 gtid) {              \
   return __kmp_release_ ## locktype ## _lock(lck, gtid);                       \
 }                                                                              \
-static inline void __kmp_init_ ## locktype ## _lock_with_checks                \
+KMP_LOCK_STATIC void __kmp_init_ ## locktype ## _lock_with_checks              \
               (kmp_ ## locktype ## _lock_t *lck) {                             \
   __kmp_init_ ## locktype ## _lock(lck);                                       \
 }                                                                              \
-static inline void __kmp_destroy_ ## locktype ## _lock_with_checks             \
+KMP_LOCK_STATIC void __kmp_destroy_ ## locktype ## _lock_with_checks           \
               (kmp_ ## locktype ## _lock_t *lck) {                             \
   __kmp_destroy_ ## locktype ## _lock(lck);                                    \
 }                                                                              \
@@ -174,43 +175,43 @@ void __kmp_destroy_nested_ ## locktype ## _lock                                \
   lck->nest_level = 0;                                                         \
   KMP_MB();                                                                    \
 }                                                                              \
-static inline int __kmp_acquire_nested_ ## locktype ## _lock_with_checks       \
+KMP_LOCK_STATIC int __kmp_acquire_nested_ ## locktype ## _lock_with_checks     \
              (kmp_ ## locktype ## _lock_t *lck, kmp_int32 gtid) {              \
   return __kmp_acquire_nested_ ## locktype ## _lock(lck, gtid);                \
 }                                                                              \
-static inline int __kmp_test_nested_ ## locktype ## _lock_with_checks          \
+KMP_LOCK_STATIC int __kmp_test_nested_ ## locktype ## _lock_with_checks        \
              (kmp_ ## locktype ## _lock_t *lck, kmp_int32 gtid) {              \
   return __kmp_test_nested_ ## locktype ## _lock(lck, gtid);                   \
 }                                                                              \
-static inline int __kmp_release_nested_ ## locktype ## _lock_with_checks       \
+KMP_LOCK_STATIC int __kmp_release_nested_ ## locktype ## _lock_with_checks     \
              (kmp_ ## locktype ## _lock_t *lck, kmp_int32 gtid) {              \
   return __kmp_release_nested_ ## locktype ## _lock(lck, gtid);                \
 }                                                                              \
-static inline void __kmp_init_nested_ ## locktype ## _lock_with_checks         \
+KMP_LOCK_STATIC void __kmp_init_nested_ ## locktype ## _lock_with_checks       \
               (kmp_ ## locktype ## _lock_t *lck) {                             \
   __kmp_init_nested_ ## locktype ## _lock(lck);                                \
 }                                                                              \
-static inline void __kmp_destroy_nested_ ## locktype ## _lock_with_checks      \
+KMP_LOCK_STATIC void __kmp_destroy_nested_ ## locktype ## _lock_with_checks    \
               (kmp_ ## locktype ## _lock_t *lck) {                             \
   __kmp_destroy_nested_ ## locktype ## _lock(lck);                             \
 }                                                                              \
-static inline const ident_t *__kmp_get_ ## locktype ## _lock_location          \
+KMP_LOCK_STATIC const ident_t *__kmp_get_ ## locktype ## _lock_location        \
                         (kmp_ ## locktype ## _lock_t *lck) {                   \
   return lck->location;                                                        \
 }                                                                              \
-static inline void __kmp_set_ ## locktype ## _lock_location                    \
+KMP_LOCK_STATIC void __kmp_set_ ## locktype ## _lock_location                  \
               (kmp_ ## locktype ## _lock_t *lck, const ident_t *loc) {         \
   lck->location = loc;                                                         \
 }                                                                              \
-static inline kmp_lock_flags_t __kmp_get_ ## locktype ## _lock_flags           \
+KMP_LOCK_STATIC kmp_lock_flags_t __kmp_get_ ## locktype ## _lock_flags         \
                           (kmp_ ## locktype ## _lock_t *lck) {                 \
   return lck->flags;                                                           \
 }                                                                              \
-static inline void __kmp_set_ ## locktype ## _lock_flags                       \
+KMP_LOCK_STATIC void __kmp_set_ ## locktype ## _lock_flags                     \
               (kmp_ ## locktype ## _lock_t *lck, kmp_lock_flags_t flags) {     \
   lck->flags = flags;                                                          \
 }                                                                              \
-static inline kmp_int32 __kmp_get_ ## locktype ## _lock_owner                  \
+KMP_LOCK_STATIC kmp_int32 __kmp_get_ ## locktype ## _lock_owner                \
                    (kmp_ ## locktype ## _lock_t *lck) {                        \
   return 0;                                                                    \
 }
@@ -229,6 +230,8 @@ typedef kmp_abt_mutex_lock_t kmp_hle_lock_t;
 KMP_DEFINE_LOCKS(hle)
 typedef kmp_abt_mutex_lock_t kmp_rtm_lock_t;
 KMP_DEFINE_LOCKS(rtm)
+
+#undef KMP_LOCK_STATIC
 
 int __kmp_acquire_bootstrap_lock(kmp_bootstrap_lock_t *lck) {
   return __kmp_abt_acquire_spin_lock(lck);

--- a/runtime/src/kmp_settings.cpp
+++ b/runtime/src/kmp_settings.cpp
@@ -354,11 +354,14 @@ static void __kmp_stg_parse_size(char const *name, char const *value,
   }
 } // __kmp_stg_parse_size
 
+
+#if KMP_AFFINITY_SUPPORTED || OMPT_SUPPORT
 static void __kmp_stg_parse_str(char const *name, char const *value,
                                 char **out) {
   __kmp_str_free(out);
   *out = __kmp_str_format("%s", value);
 } // __kmp_stg_parse_str
+#endif
 
 static void __kmp_stg_parse_int(
     char const

--- a/runtime/src/kmp_wrapper_getpid.h
+++ b/runtime/src/kmp_wrapper_getpid.h
@@ -22,7 +22,12 @@
 #include <unistd.h>
 #if KMP_OS_DARWIN
 // OS X
-#define __kmp_gettid() syscall(SYS_thread_selfid)
+#include <pthread.h>
+static inline long __kmp_gettid() {
+  uint64_t tid64;
+  pthread_threadid_np(NULL, &tid64);
+  return (long)tid64;
+}
 #elif KMP_OS_FREEBSD
 #include <pthread_np.h>
 #define __kmp_gettid() pthread_getthreadid_np()

--- a/runtime/test/CMakeLists.txt
+++ b/runtime/test/CMakeLists.txt
@@ -2,6 +2,12 @@
 include(CheckFunctionExists)
 include(CheckLibraryExists)
 
+# Remove -Werror
+set(CMAKE_C_FLAGS "${CMAKE_ORIG_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_ORIG_CXX_FLAGS}")
+string(REPLACE " -Werror" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+string(REPLACE " -Werror" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+
 # Some tests use math functions
 check_library_exists(m sqrt "" LIBOMP_HAVE_LIBM)
 # When using libgcc, -latomic may be needed for atomics
@@ -15,6 +21,10 @@ else()
   # not needed
   set(LIBOMP_HAVE_LIBATOMIC 0)
 endif()
+
+# Undo changes
+set(CMAKE_ORIG_C_FLAGS "${CMAKE_C_FLAGS}")
+set(CMAKE_ORIG_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 macro(pythonize_bool var)
   if (${var})


### PR DESCRIPTION
LLVM OpenMP upstream is now warning-free. This PR removes standard compile-time warnings from BOLT so that we can compile it with `-DOPENMP_ENABLE_WERROR=TRUE`.

Our automated tests will add `-DOPENMP_ENABLE_WERROR=TRUE`.