### PR TITLE
test: add BOLT-specific tests

### DIFF
--- a/runtime/test/bolt/interop/init_then_openmp.c
+++ b/runtime/test/bolt/interop/init_then_openmp.c
@@ -1,0 +1,37 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include <stdio.h>
+
+int test_init_then_openmp(int num_init) {
+  int i;
+  int val = 0;
+
+  for (i = 0; i < num_init; i++) {
+    ABT_EXIT_IF_FAIL(ABT_init(0, 0));
+  }
+
+  #pragma omp parallel num_threads(NUM_TASKS)
+  {
+    #pragma omp master
+    { val = 1; }
+  }
+
+  for (i = 0; i < num_init; i++) {
+    ABT_EXIT_IF_FAIL(ABT_finalize());
+  }
+
+  return val;
+}
+
+int main() {
+  int i;
+  int num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    // Note that Argobots will be initialized once BOLT is instantiated.
+    if (!test_init_then_openmp(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/interop/openmp_then_init.c
+++ b/runtime/test/bolt/interop/openmp_then_init.c
@@ -1,0 +1,37 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include <stdio.h>
+
+int test_openmp_then_init(int num_init) {
+  int i;
+  int val = 0;
+
+  #pragma omp parallel num_threads(NUM_TASKS)
+  {
+    #pragma omp master
+    {
+      int initialized = (ABT_initialized() == ABT_SUCCESS);
+      for (i = 0; i < num_init; i++) {
+        ABT_EXIT_IF_FAIL(ABT_init(0, 0));
+      }
+      val = initialized ? 1 : 0;
+      for (i = 0; i < num_init; i++) {
+        ABT_EXIT_IF_FAIL(ABT_finalize());
+      }
+    }
+  }
+  return val;
+}
+
+int main() {
+  int i;
+  int num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    // Note that Argobots will be initialized once BOLT is instantiated.
+    if (!test_openmp_then_init(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/misc_bugs/untied_tasks.c
+++ b/runtime/test/bolt/misc_bugs/untied_tasks.c
@@ -1,0 +1,61 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+
+int test_omp_untied_tasks()
+{
+  // https://github.com/pmodels/bolt/issues/49
+  int val = 0;
+  #pragma omp parallel
+  #pragma omp master
+  {
+    #pragma omp task untied
+    { val = 1; }
+  }
+  return val;
+}
+
+int test_omp_tied_tasks()
+{
+  int val = 0;
+  #pragma omp parallel
+  #pragma omp master
+  {
+    #pragma omp task
+    { val = 1; }
+  }
+  return val;
+}
+
+int test_omp_tied_and_untied_tasks()
+{
+  int val1 = 0;
+  int val2 = 0;
+  #pragma omp parallel
+  #pragma omp master
+  {
+    #pragma omp task
+    { val1 = 1; }
+    #pragma omp task untied
+    { val2 = 1; }
+  }
+  return val1 == 1 && val2 == 1;
+}
+
+int main()
+{
+  int i;
+  int num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_omp_untied_tasks()) {
+      num_failed++;
+    }
+    if (!test_omp_tied_tasks()) {
+      num_failed++;
+    }
+    if (!test_omp_tied_and_untied_tasks()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/bolt_scheduling_util.h
+++ b/runtime/test/bolt/scheduling/bolt_scheduling_util.h
@@ -1,0 +1,77 @@
+
+#ifndef BOLT_SCHEDULING_UTIL_H
+#define BOLT_SCHEDULING_UTIL_H
+
+#include "omp_testsuite.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sched.h>
+
+void check_num_ess(int desired) {
+  int num_xstreams;
+  ABT_EXIT_IF_FAIL(ABT_xstream_get_num(&num_xstreams));
+  if (num_xstreams != desired) {
+    printf("check_num_ess: num_xstreams (%d) != desired (%d)\n", num_xstreams,
+           desired);
+    exit(1);
+  }
+}
+
+typedef struct {
+  int counter, flag;
+} timeout_barrier_t;
+
+void timeout_barrier_init(timeout_barrier_t *barrier) {
+  barrier->counter = 0;
+  barrier->flag = 0;
+}
+
+void timeout_barrier_wait(timeout_barrier_t *barrier, int num_waiters) {
+  const int timeout_ms = 4000;
+  const int wait_ms = 200;
+
+  // return 1 if failed.
+  int *p_counter = &barrier->counter;
+  int *p_flag = &barrier->flag;
+
+  if (__atomic_add_fetch(p_counter, 1, __ATOMIC_ACQ_REL) == num_waiters) {
+    double start_time = omp_get_wtime();
+    while (omp_get_wtime() < start_time + wait_ms / 1000.0) {
+      if (__atomic_load_n(p_counter, __ATOMIC_ACQUIRE) != num_waiters) {
+        printf("timeout_barrier_wait: # of arrivals > num_waiters (%d)\n", num_waiters);
+        exit(1);
+      }
+      sched_yield();
+    }
+    // Going back to the normal barrier implementation.
+    __atomic_store_n(p_flag, 1, __ATOMIC_RELEASE);
+    // wait until current_counter gets 1
+    do {
+      // This does not require timeout.
+      sched_yield();
+    } while (__atomic_load_n(p_counter, __ATOMIC_ACQUIRE) != 1);
+    // update a flag again.
+    __atomic_store_n(p_counter, 0, __ATOMIC_RELEASE);
+    __atomic_store_n(p_flag, 0, __ATOMIC_RELEASE);
+  } else {
+    double start_time = omp_get_wtime();
+    do {
+      if (omp_get_wtime() > start_time + (timeout_ms + wait_ms) / 1000.0) {
+        printf("timeout_barrier_wait: timeout expires (%d)\n",
+               (int)__atomic_load_n(p_counter, __ATOMIC_ACQUIRE));
+        exit(1);
+      }
+      sched_yield();
+    } while (__atomic_load_n(p_flag, __ATOMIC_ACQUIRE) == 0);
+    // now p_flag is 1. Let's decrease the counter.
+    __atomic_sub_fetch(p_counter, 1, __ATOMIC_ACQ_REL);
+    // wait until p_flag gets 0.
+    do {
+      // This does not require timeout.
+      sched_yield();
+    } while (__atomic_load_n(p_flag, __ATOMIC_ACQUIRE) == 1);
+  }
+}
+
+#endif // BOLT_SCHEDULING_UTIL_H

--- a/runtime/test/bolt/scheduling/for_nowait_scheduling.c
+++ b/runtime/test/bolt/scheduling/for_nowait_scheduling.c
@@ -1,0 +1,47 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+
+int test_for_nowait_scheduling() {
+  int i, vals[4];
+  memset(vals, 0, sizeof(int) * 4);
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel num_threads(4)
+  {
+    check_num_ess(4);
+    int tid = omp_get_thread_num();
+    #pragma omp for nowait
+    for (i = 0; i < 4; i++) {
+      if (tid < 2) {
+        timeout_barrier_wait(&barrier, 4);
+      }
+    }
+    if (tid >= 2) {
+      // The following barrier must be synchronized with the "for" above.
+      timeout_barrier_wait(&barrier, 4);
+    }
+    vals[omp_get_thread_num()] = 1;
+  }
+
+  for (i = 0; i < 4; i++) {
+    if (vals[i] != 1) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 1; i < REPETITIONS; i++) {
+    if (!test_for_nowait_scheduling(i)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/task_tied_scheduling.c
+++ b/runtime/test/bolt/scheduling/task_tied_scheduling.c
@@ -1,0 +1,49 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+
+int test_task_tied_scheduling() {
+  int i, vals[6];
+  memset(vals, 0, sizeof(int) * 6);
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel num_threads(4)
+  {
+    // 6 barrier_waits in tasks and 2 barrier_waits in threads
+    #pragma omp master
+    {
+      check_num_ess(4);
+      for (i = 0; i < 6; i++) {
+        #pragma omp task firstprivate(i)
+        {
+          timeout_barrier_wait(&barrier, 4);
+          vals[i] = 1;
+        }
+      }
+    }
+    if (omp_get_thread_num() < 2) {
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  for (i = 0; i < 6; i++) {
+    if (vals[i] != 1) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_task_tied_scheduling(i)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/task_tied_thread_scheduling.c
+++ b/runtime/test/bolt/scheduling/task_tied_thread_scheduling.c
@@ -1,0 +1,76 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+
+int test_task_tied_thread_scheduling(int num_threads) {
+  int vals[num_threads * num_threads];
+  memset(vals, 0, sizeof(int) * num_threads * num_threads);
+  omp_set_max_active_levels(2);
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel num_threads(num_threads)
+  #pragma omp master
+  {
+    check_num_ess(4);
+    int i;
+    for (i = 0; i < num_threads; i++) {
+      #pragma omp task firstprivate(i)
+      {
+        #pragma omp parallel num_threads(num_threads)
+        {
+          if (omp_get_thread_num() == 1) {
+            // We should not block a master thread since it might need to create
+            // other outer tasks.
+            timeout_barrier_wait(&barrier, 4);
+          }
+          vals[i * num_threads + omp_get_thread_num()] += 1;
+        }
+      }
+    }
+  }
+
+  #pragma omp parallel num_threads(num_threads)
+  #pragma omp master
+  {
+    check_num_ess(4);
+    int i;
+    for (i = 0; i < num_threads; i++) {
+      #pragma omp task firstprivate(i)
+      {
+        int j;
+        #pragma omp parallel for num_threads(num_threads)
+        for (j = 0; j < num_threads; j++) {
+          if (omp_get_thread_num() == 1) {
+            // We should not block a master thread since it might need to create
+            // other outer tasks.
+            timeout_barrier_wait(&barrier, 4);
+          }
+          vals[i * num_threads + j] += 2;
+        }
+      }
+    }
+  }
+
+  int index;
+  for (index = 0; index < num_threads * num_threads; index++) {
+    if (vals[index] != 3) {
+      printf("vals[%d] == %d\n", index, vals[index]);
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 1; i < 3; i++) {
+    if (!test_task_tied_thread_scheduling(i * 4)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/task_unitied_scheduling.c
+++ b/runtime/test/bolt/scheduling/task_unitied_scheduling.c
@@ -1,0 +1,69 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+
+int test_task_untied_scheduling() {
+  int i, vals[6];
+  memset(vals, 0, sizeof(int) * 6);
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel num_threads(4)
+  {
+    // 6 barrier_waits in tasks and 2 barrier_waits in threads
+    #pragma omp master
+    {
+      check_num_ess(4);
+      for (i = 0; i < 6; i++) {
+        #pragma omp task firstprivate(i) untied
+        {
+          timeout_barrier_wait(&barrier, 4);
+          vals[i] = 1;
+        }
+      }
+    }
+    if (omp_get_thread_num() < 2) {
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  #pragma omp parallel num_threads(4)
+  {
+    // 6 barrier_waits in tasks and 2 barrier_waits in threads
+    #pragma omp master
+    {
+      check_num_ess(4);
+      for (i = 0; i < 6; i++) {
+        #pragma omp task firstprivate(i) untied
+        {
+          #pragma omp taskyield
+          timeout_barrier_wait(&barrier, 4);
+          vals[i] += 2;
+        }
+      }
+    }
+    if (omp_get_thread_num() < 2) {
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  for (i = 0; i < 6; i++) {
+    if (vals[i] != 3) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_task_untied_scheduling()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/task_untied_thread_scheduling.c
+++ b/runtime/test/bolt/scheduling/task_untied_thread_scheduling.c
@@ -1,0 +1,74 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+
+int test_task_untied_thread_scheduling(int num_threads) {
+  int vals[num_threads * num_threads];
+  memset(vals, 0, sizeof(int) * num_threads * num_threads);
+  omp_set_max_active_levels(2);
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel num_threads(num_threads)
+  #pragma omp master
+  {
+    check_num_ess(4);
+    int i;
+    for (i = 0; i < num_threads; i++) {
+      #pragma omp task firstprivate(i) untied
+      {
+        #pragma omp parallel num_threads(num_threads)
+        {
+          if (omp_get_thread_num() == 0) {
+            // We can block a master thread since the associated task is untied
+            timeout_barrier_wait(&barrier, 4);
+          }
+          vals[i * num_threads + omp_get_thread_num()] += 1;
+        }
+      }
+    }
+  }
+
+  #pragma omp parallel num_threads(num_threads)
+  #pragma omp master
+  {
+    check_num_ess(4);
+    int i;
+    for (i = 0; i < num_threads; i++) {
+      #pragma omp task firstprivate(i) untied
+      {
+        int j;
+        #pragma omp parallel for num_threads(num_threads)
+        for (j = 0; j < num_threads; j++) {
+          if (omp_get_thread_num() == 0) {
+            // We can block a master thread since the associated task is untied
+            timeout_barrier_wait(&barrier, 4);
+          }
+          vals[i * num_threads + j] += 2;
+        }
+      }
+    }
+  }
+
+  int index;
+  for (index = 0; index < num_threads * num_threads; index++) {
+    if (vals[index] != 3) {
+      printf("vals[%d] == %d\n", index, vals[index]);
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 1; i < 3; i++) {
+    if (!test_task_untied_thread_scheduling(i * 4)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskdep_taskgroup_tied_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskdep_taskgroup_tied_scheduling.c
@@ -1,0 +1,123 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+int test_taskdep_taskgroup_tied_scheduilng() {
+  int n = 6;
+  int seq_val, task_val;
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(4)
+  {
+    #pragma omp master
+    {
+      // 6 ( = n) barrier_waits in diagonal tasks and 2 barrier_waits in threads
+      check_num_ess(4);
+      int i, j;
+      int *A_buf = (int *)malloc(sizeof(int) * n * n);
+      int **A = (int **)malloc(sizeof(int *) * n);
+      for(i = 0; i < n; i++) {
+        A[i] = A_buf + (i * n);
+        for(j = 0; j < n; j++) {
+          // Assign random values.
+          A[i][j] = i * n + j;
+        }
+      }
+      #pragma omp taskgroup
+      {
+        // A[i][j] is the root task.
+        for(i = 0; i < n; i++) {
+          for(j = 0; j < n; j++) {
+            if (i == 0 && j == 0) {
+              #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j)
+              {
+                if (i + j == n - 1) {
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = 1;
+              }
+            } else if (i == 0) {
+              #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                               firstprivate(A, i, j)
+              {
+                if (i + j == n - 1) {
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = A[i][j - 1];
+              }
+            } else if (j == 0) {
+              #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                               firstprivate(A, i, j)
+              {
+                if (i + j == n - 1) {
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = A[i - 1][j];
+              }
+            } else {
+              #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                               depend(out:A[i][j])
+              {
+                if (i + j == n - 1) {
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = A[i - 1][j] + A[i][j - 1];
+              }
+            }
+          }
+        }
+      }
+      task_val = A[n - 1][n - 1];
+      free(A);
+      free(A_buf);
+    }
+    if (omp_get_thread_num() >= 2) {
+      // The master thread needs to wait for tasks, so non-master threads should
+      // run it.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("Failed: route(%d) = %d (ANS = %d)\n", n, task_val, seq_val);
+    return 0;
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_taskgroup_tied_scheduilng()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskdep_taskgroup_untied_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskdep_taskgroup_untied_scheduling.c
@@ -1,0 +1,123 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+int test_taskdep_taskgroup_untied_scheduilng() {
+  int n = 6;
+  int seq_val, task_val;
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(4)
+  {
+    #pragma omp master
+    {
+      // 6 ( = n) barrier_waits in diagonal tasks and 2 barrier_waits in threads
+      check_num_ess(4);
+      int i, j;
+      int *A_buf = (int *)malloc(sizeof(int) * n * n);
+      int **A = (int **)malloc(sizeof(int *) * n);
+      for(i = 0; i < n; i++) {
+        A[i] = A_buf + (i * n);
+        for(j = 0; j < n; j++) {
+          // Assign random values.
+          A[i][j] = i * n + j;
+        }
+      }
+      #pragma omp taskgroup
+      {
+        // A[i][j] is the root task.
+        for(i = 0; i < n; i++) {
+          for(j = 0; j < n; j++) {
+            if (i == 0 && j == 0) {
+              #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j) untied
+              {
+                if (i + j == n - 1) {
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = 1;
+              }
+            } else if (i == 0) {
+              #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                               firstprivate(A, i, j) untied
+              {
+                if (i + j == n - 1) {
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = A[i][j - 1];
+              }
+            } else if (j == 0) {
+              #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                               firstprivate(A, i, j) untied
+              {
+                if (i + j == n - 1) {
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = A[i - 1][j];
+              }
+            } else {
+              #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                               depend(out:A[i][j]) untied
+              {
+                if (i + j == n - 1) {
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = A[i - 1][j] + A[i][j - 1];
+              }
+            }
+          }
+        }
+      }
+      task_val = A[n - 1][n - 1];
+      free(A);
+      free(A_buf);
+    }
+    if (omp_get_thread_num() >= 2) {
+      // The master thread needs to wait for tasks, so non-master threads should
+      // run it.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("Failed: route(%d) = %d (ANS = %d)\n", n, task_val, seq_val);
+    return 0;
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_taskgroup_untied_scheduilng()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskdep_taskgroup_untied_yield_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskdep_taskgroup_untied_yield_scheduling.c
@@ -1,0 +1,127 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+int test_taskdep_taskgroup_untied_yield_scheduilng() {
+  int n = 6;
+  int seq_val, task_val;
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(4)
+  {
+    #pragma omp master
+    {
+      // 6 ( = n) barrier_waits in diagonal tasks and 2 barrier_waits in threads
+      check_num_ess(4);
+      int i, j;
+      int *A_buf = (int *)malloc(sizeof(int) * n * n);
+      int **A = (int **)malloc(sizeof(int *) * n);
+      for(i = 0; i < n; i++) {
+        A[i] = A_buf + (i * n);
+        for(j = 0; j < n; j++) {
+          // Assign random values.
+          A[i][j] = i * n + j;
+        }
+      }
+      #pragma omp taskgroup
+      {
+        // A[i][j] is the root task.
+        for(i = 0; i < n; i++) {
+          for(j = 0; j < n; j++) {
+            if (i == 0 && j == 0) {
+              #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j) untied
+              {
+                if (i + j == n - 1) {
+                  #pragma omp taskyield
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = 1;
+              }
+            } else if (i == 0) {
+              #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                               firstprivate(A, i, j) untied
+              {
+                if (i + j == n - 1) {
+                  #pragma omp taskyield
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = A[i][j - 1];
+              }
+            } else if (j == 0) {
+              #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                               firstprivate(A, i, j) untied
+              {
+                if (i + j == n - 1) {
+                  #pragma omp taskyield
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = A[i - 1][j];
+              }
+            } else {
+              #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                               depend(out:A[i][j]) untied
+              {
+                if (i + j == n - 1) {
+                  #pragma omp taskyield
+                  timeout_barrier_wait(&barrier, 4);
+                }
+                A[i][j] = A[i - 1][j] + A[i][j - 1];
+              }
+            }
+          }
+        }
+      }
+      task_val = A[n - 1][n - 1];
+      free(A);
+      free(A_buf);
+    }
+    if (omp_get_thread_num() >= 2) {
+      // The master thread needs to wait for tasks, so non-master threads should
+      // run it.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("Failed: route(%d) = %d (ANS = %d)\n", n, task_val, seq_val);
+    return 0;
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_taskgroup_untied_yield_scheduilng()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskdep_taskwait_tied_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskdep_taskwait_tied_scheduling.c
@@ -1,0 +1,121 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+int test_taskdep_taskwait_tied_scheduilng() {
+  int n = 6;
+  int seq_val, task_val;
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(4)
+  {
+    #pragma omp master
+    {
+      // 6 ( = n) barrier_waits in diagonal tasks and 2 barrier_waits in threads
+      check_num_ess(4);
+      int i, j;
+      int *A_buf = (int *)malloc(sizeof(int) * n * n);
+      int **A = (int **)malloc(sizeof(int *) * n);
+      for(i = 0; i < n; i++) {
+        A[i] = A_buf + (i * n);
+        for(j = 0; j < n; j++) {
+          // Assign random values.
+          A[i][j] = i * n + j;
+        }
+      }
+      // A[i][j] is the root task.
+      for(i = 0; i < n; i++) {
+        for(j = 0; j < n; j++) {
+          if (i == 0 && j == 0) {
+            #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j)
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = 1;
+            }
+          } else if (i == 0) {
+            #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j)
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i][j - 1];
+            }
+          } else if (j == 0) {
+            #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j)
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j];
+            }
+          } else {
+            #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                             depend(out:A[i][j])
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j] + A[i][j - 1];
+            }
+          }
+        }
+      }
+      #pragma omp taskwait
+      task_val = A[n - 1][n - 1];
+      free(A);
+      free(A_buf);
+    }
+    if (omp_get_thread_num() >= 2) {
+      // The master thread needs to wait for tasks, so non-master threads should
+      // run it.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("Failed: route(%d) = %d (ANS = %d)\n", n, task_val, seq_val);
+    return 0;
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_taskwait_tied_scheduilng()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskdep_taskwait_untied_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskdep_taskwait_untied_scheduling.c
@@ -1,0 +1,121 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+int test_taskdep_taskwait_untied_scheduilng() {
+  int n = 6;
+  int seq_val, task_val;
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(4)
+  {
+    #pragma omp master
+    {
+      // 6 ( = n) barrier_waits in diagonal tasks and 2 barrier_waits in threads
+      check_num_ess(4);
+      int i, j;
+      int *A_buf = (int *)malloc(sizeof(int) * n * n);
+      int **A = (int **)malloc(sizeof(int *) * n);
+      for(i = 0; i < n; i++) {
+        A[i] = A_buf + (i * n);
+        for(j = 0; j < n; j++) {
+          // Assign random values.
+          A[i][j] = i * n + j;
+        }
+      }
+      // A[i][j] is the root task.
+      for(i = 0; i < n; i++) {
+        for(j = 0; j < n; j++) {
+          if (i == 0 && j == 0) {
+            #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = 1;
+            }
+          } else if (i == 0) {
+            #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i][j - 1];
+            }
+          } else if (j == 0) {
+            #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j];
+            }
+          } else {
+            #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                             depend(out:A[i][j]) untied
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j] + A[i][j - 1];
+            }
+          }
+        }
+      }
+      #pragma omp taskwait
+      task_val = A[n - 1][n - 1];
+      free(A);
+      free(A_buf);
+    }
+    if (omp_get_thread_num() >= 2) {
+      // The master thread needs to wait for tasks, so non-master threads should
+      // run it.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("Failed: route(%d) = %d (ANS = %d)\n", n, task_val, seq_val);
+    return 0;
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_taskwait_untied_scheduilng()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskdep_taskwait_untied_yield_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskdep_taskwait_untied_yield_scheduling.c
@@ -1,0 +1,125 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+int test_taskdep_taskwait_untied_yield_scheduilng() {
+  int n = 6;
+  int seq_val, task_val;
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(4)
+  {
+    #pragma omp master
+    {
+      // 6 ( = n) barrier_waits in diagonal tasks and 2 barrier_waits in threads
+      check_num_ess(4);
+      int i, j;
+      int *A_buf = (int *)malloc(sizeof(int) * n * n);
+      int **A = (int **)malloc(sizeof(int *) * n);
+      for(i = 0; i < n; i++) {
+        A[i] = A_buf + (i * n);
+        for(j = 0; j < n; j++) {
+          // Assign random values.
+          A[i][j] = i * n + j;
+        }
+      }
+      // A[i][j] is the root task.
+      for(i = 0; i < n; i++) {
+        for(j = 0; j < n; j++) {
+          if (i == 0 && j == 0) {
+            #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                #pragma omp taskyield
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = 1;
+            }
+          } else if (i == 0) {
+            #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                #pragma omp taskyield
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i][j - 1];
+            }
+          } else if (j == 0) {
+            #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                #pragma omp taskyield
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j];
+            }
+          } else {
+            #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                             depend(out:A[i][j]) untied
+            {
+              if (i + j == n - 1) {
+                #pragma omp taskyield
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j] + A[i][j - 1];
+            }
+          }
+        }
+      }
+      #pragma omp taskwait
+      task_val = A[n - 1][n - 1];
+      free(A);
+      free(A_buf);
+    }
+    if (omp_get_thread_num() >= 2) {
+      // The master thread needs to wait for tasks, so non-master threads should
+      // run it.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("Failed: route(%d) = %d (ANS = %d)\n", n, task_val, seq_val);
+    return 0;
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_taskwait_untied_yield_scheduilng()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskdep_tied_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskdep_tied_scheduling.c
@@ -1,0 +1,122 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+int test_taskdep_tied_scheduilng() {
+  int n = 6;
+  int seq_val, task_val;
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  int *A_buf = (int *)malloc(sizeof(int) * n * n);
+  int **A = (int **)malloc(sizeof(int *) * n);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(4)
+  {
+    #pragma omp master
+    {
+      // 6 ( = n) barrier_waits in diagonal tasks and 2 barrier_waits in threads
+      check_num_ess(4);
+      int i, j;
+      for(i = 0; i < n; i++) {
+        A[i] = A_buf + (i * n);
+        for(j = 0; j < n; j++) {
+          // Assign random values.
+          A[i][j] = i * n + j;
+        }
+      }
+      // A[i][j] is the root task.
+      for(i = 0; i < n; i++) {
+        for(j = 0; j < n; j++) {
+          if (i == 0 && j == 0) {
+            #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j)
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = 1;
+            }
+          } else if (i == 0) {
+            #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j)
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i][j - 1];
+            }
+          } else if (j == 0) {
+            #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j)
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j];
+            }
+          } else {
+            #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                             depend(out:A[i][j])
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j] + A[i][j - 1];
+            }
+          }
+        }
+      }
+    }
+    if (omp_get_thread_num() < 2) {
+      // The master thread does not need to wait for tasks, so the master thread
+      // can execute the following after task creation.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  task_val = A[n - 1][n - 1];
+  free(A);
+  free(A_buf);
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("Failed: route(%d) = %d (ANS = %d)\n", n, task_val, seq_val);
+    return 0;
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_tied_scheduilng()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskdep_untied_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskdep_untied_scheduling.c
@@ -1,0 +1,122 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+int test_taskdep_untied_scheduilng() {
+  int n = 6;
+  int seq_val, task_val;
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  int *A_buf = (int *)malloc(sizeof(int) * n * n);
+  int **A = (int **)malloc(sizeof(int *) * n);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(4)
+  {
+    #pragma omp master
+    {
+      // 6 ( = n) barrier_waits in diagonal tasks and 2 barrier_waits in threads
+      check_num_ess(4);
+      int i, j;
+      for(i = 0; i < n; i++) {
+        A[i] = A_buf + (i * n);
+        for(j = 0; j < n; j++) {
+          // Assign random values.
+          A[i][j] = i * n + j;
+        }
+      }
+      // A[i][j] is the root task.
+      for(i = 0; i < n; i++) {
+        for(j = 0; j < n; j++) {
+          if (i == 0 && j == 0) {
+            #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = 1;
+            }
+          } else if (i == 0) {
+            #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i][j - 1];
+            }
+          } else if (j == 0) {
+            #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j];
+            }
+          } else {
+            #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                             depend(out:A[i][j]) untied
+            {
+              if (i + j == n - 1) {
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j] + A[i][j - 1];
+            }
+          }
+        }
+      }
+    }
+    if (omp_get_thread_num() < 2) {
+      // The master thread does not need to wait for tasks, so the master thread
+      // can execute the following after task creation.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  task_val = A[n - 1][n - 1];
+  free(A);
+  free(A_buf);
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("Failed: route(%d) = %d (ANS = %d)\n", n, task_val, seq_val);
+    return 0;
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_untied_scheduilng()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskdep_untied_yield_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskdep_untied_yield_scheduling.c
@@ -1,0 +1,126 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+int test_taskdep_untied_yield_scheduilng() {
+  int n = 6;
+  int seq_val, task_val;
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  int *A_buf = (int *)malloc(sizeof(int) * n * n);
+  int **A = (int **)malloc(sizeof(int *) * n);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(4)
+  {
+    #pragma omp master
+    {
+      // 6 ( = n) barrier_waits in diagonal tasks and 2 barrier_waits in threads
+      check_num_ess(4);
+      int i, j;
+      for(i = 0; i < n; i++) {
+        A[i] = A_buf + (i * n);
+        for(j = 0; j < n; j++) {
+          // Assign random values.
+          A[i][j] = i * n + j;
+        }
+      }
+      // A[i][j] is the root task.
+      for(i = 0; i < n; i++) {
+        for(j = 0; j < n; j++) {
+          if (i == 0 && j == 0) {
+            #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                #pragma omp taskyield
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = 1;
+            }
+          } else if (i == 0) {
+            #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                #pragma omp taskyield
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i][j - 1];
+            }
+          } else if (j == 0) {
+            #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                             firstprivate(A, i, j) untied
+            {
+              if (i + j == n - 1) {
+                #pragma omp taskyield
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j];
+            }
+          } else {
+            #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                             depend(out:A[i][j]) untied
+            {
+              if (i + j == n - 1) {
+                #pragma omp taskyield
+                timeout_barrier_wait(&barrier, 4);
+              }
+              A[i][j] = A[i - 1][j] + A[i][j - 1];
+            }
+          }
+        }
+      }
+    }
+    if (omp_get_thread_num() < 2) {
+      // The master thread does not need to wait for tasks, so the master thread
+      // can execute the following after task creation.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  task_val = A[n - 1][n - 1];
+  free(A);
+  free(A_buf);
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("Failed: route(%d) = %d (ANS = %d)\n", n, task_val, seq_val);
+    return 0;
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_untied_yield_scheduilng()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskloop_nogroup_tied_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskloop_nogroup_tied_scheduling.c
@@ -1,0 +1,48 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+
+int test_taskloop_nogroup_tied_scheduling() {
+  int i, vals[6];
+  memset(vals, 0, sizeof(int) * 6);
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel num_threads(4)
+  {
+    // 6 barrier_waits in tasks and 2 barrier_waits in threads
+    #pragma omp master
+    {
+      check_num_ess(4);
+      #pragma omp taskloop grainsize(1) nogroup
+      for (i = 0; i < 6; i++) {
+        timeout_barrier_wait(&barrier, 4);
+        vals[i] = 1;
+      }
+    }
+    if (omp_get_thread_num() < 2) {
+      // master does not wait the completion of taskloop.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  for (i = 0; i < 6; i++) {
+    if (vals[i] != 1) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskloop_nogroup_tied_scheduling()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskloop_nogroup_untied_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskloop_nogroup_untied_scheduling.c
@@ -1,0 +1,70 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt && !clang
+
+// Clang 10.0 seems ignoring the taskloop's "untied" attribute.
+// We mark taskloop + untied with Clang as unsupported so far.
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+
+int test_taskloop_nogroup_untied_scheduling() {
+  int i, vals[6];
+  memset(vals, 0, sizeof(int) * 6);
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel num_threads(4)
+  {
+    // 6 barrier_waits in tasks and 2 barrier_waits in threads
+    #pragma omp master
+    {
+      check_num_ess(4);
+      #pragma omp taskloop grainsize(1) nogroup untied
+      for (i = 0; i < 6; i++) {
+        timeout_barrier_wait(&barrier, 4);
+        vals[i] = 1;
+      }
+    }
+    if (omp_get_thread_num() < 2) {
+      // master does not wait the completion of taskloop.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  #pragma omp parallel num_threads(4)
+  {
+    // 6 barrier_waits in tasks and 2 barrier_waits in threads
+    #pragma omp master
+    {
+      check_num_ess(4);
+      #pragma omp taskloop grainsize(1) nogroup untied
+      for (i = 0; i < 6; i++) {
+        #pragma omp taskyield
+        timeout_barrier_wait(&barrier, 4);
+        vals[i] = 1;
+      }
+    }
+    if (omp_get_thread_num() < 2) {
+      // master does not wait the completion of taskloop.
+      timeout_barrier_wait(&barrier, 4);
+    }
+  }
+
+  for (i = 0; i < 6; i++) {
+    if (vals[i] != 1) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskloop_nogroup_untied_scheduling()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskloop_tied_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskloop_tied_scheduling.c
@@ -1,0 +1,47 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+
+int test_taskloop_tied_scheduling() {
+  int i, vals[6];
+  memset(vals, 0, sizeof(int) * 6);
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel num_threads(4)
+  {
+    if (omp_get_thread_num() >= 2) {
+      timeout_barrier_wait(&barrier, 4);
+    }
+    // 6 barrier_waits in tasks and 2 barrier_waits in threads
+    #pragma omp master
+    {
+      check_num_ess(4);
+      #pragma omp taskloop grainsize(1)
+      for (i = 0; i < 6; i++) {
+        timeout_barrier_wait(&barrier, 4);
+        vals[i] = 1;
+      }
+    }
+  }
+
+  for (i = 0; i < 6; i++) {
+    if (vals[i] != 1) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskloop_tied_scheduling()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/taskloop_untied_scheduling.c
+++ b/runtime/test/bolt/scheduling/taskloop_untied_scheduling.c
@@ -1,0 +1,68 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt && !clang
+
+// Clang 10.0 seems ignoring the taskloop's "untied" attribute.
+// We mark taskloop + untied with Clang as unsupported so far.
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+
+int test_taskloop_untied_scheduling() {
+  int i, vals[6];
+  memset(vals, 0, sizeof(int) * 6);
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel num_threads(4)
+  {
+    if (omp_get_thread_num() >= 2) {
+      timeout_barrier_wait(&barrier, 4);
+    }
+    // 6 barrier_waits in tasks and 2 barrier_waits in threads
+    #pragma omp master
+    {
+      check_num_ess(4);
+      #pragma omp taskloop grainsize(1) untied
+      for (i = 0; i < 6; i++) {
+        timeout_barrier_wait(&barrier, 4);
+        vals[i] += 1;
+      }
+    }
+  }
+
+  #pragma omp parallel num_threads(4)
+  {
+    if (omp_get_thread_num() >= 2) {
+      timeout_barrier_wait(&barrier, 4);
+    }
+    // 6 barrier_waits in tasks and 2 barrier_waits in threads
+    #pragma omp master
+    {
+      check_num_ess(4);
+      #pragma omp taskloop grainsize(1) untied
+      for (i = 0; i < 6; i++) {
+        #pragma omp taskyield
+        timeout_barrier_wait(&barrier, 4);
+        vals[i] += 2;
+      }
+    }
+  }
+
+  for (i = 0; i < 6; i++) {
+    if (vals[i] != 3) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskloop_untied_scheduling()) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/thread_scheduling.c
+++ b/runtime/test/bolt/scheduling/thread_scheduling.c
@@ -1,0 +1,46 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+
+int test_thread_scheduling(int num_threads) {
+  int i, vals[num_threads];
+  memset(vals, 0, sizeof(int) * num_threads);
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel num_threads(num_threads)
+  {
+    check_num_ess(4);
+    // The barrier must be run by all ESs.
+    timeout_barrier_wait(&barrier, 4);
+    vals[omp_get_thread_num()] += 1;
+  }
+
+  #pragma omp parallel for num_threads(num_threads)
+  for (i = 0; i < num_threads; i++) {
+    check_num_ess(4);
+    // The barrier must be run by all ESs.
+    timeout_barrier_wait(&barrier, 4);
+    vals[i] += 2;
+  }
+
+  for (i = 0; i < num_threads; i++) {
+    if (vals[i] != 3) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 1; i < 4; i++) {
+    if (!test_thread_scheduling(i * 4)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/scheduling/thread_thread_scheduling.c
+++ b/runtime/test/bolt/scheduling/thread_thread_scheduling.c
@@ -1,0 +1,58 @@
+// RUN: %libomp-compile && env KMP_ABT_NUM_ESS=4 %libomp-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include "bolt_scheduling_util.h"
+
+int test_thread_thread_scheduling(int num_threads) {
+  int i, vals[num_threads * num_threads];
+  memset(vals, 0, sizeof(int) * num_threads * num_threads);
+  omp_set_max_active_levels(2);
+
+  timeout_barrier_t barrier;
+  timeout_barrier_init(&barrier);
+
+  #pragma omp parallel num_threads(num_threads)
+  {
+    check_num_ess(4);
+    int parent_tid = omp_get_thread_num();
+    #pragma omp parallel num_threads(num_threads)
+    {
+      if (parent_tid == omp_get_thread_num()) {
+        timeout_barrier_wait(&barrier, 4);
+      }
+      vals[parent_tid * num_threads + omp_get_thread_num()] += 1;
+    }
+  }
+
+  #pragma omp parallel for num_threads(num_threads)
+  for (i = 0; i < num_threads; i++) {
+    check_num_ess(4);
+    int j, parent_i = i;
+    #pragma omp parallel for num_threads(num_threads)
+    for (j = 0; j < num_threads; j++) {
+      if (parent_i == j) {
+        timeout_barrier_wait(&barrier, 4);
+      }
+      vals[parent_i * num_threads + j] += 2;
+    }
+  }
+
+  for (i = 0; i < num_threads * num_threads; i++) {
+    if (vals[i] != 3) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 1; i < 3; i++) {
+    if (!test_thread_thread_scheduling(i * 4)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/task_tied_thread_threadid.c
+++ b/runtime/test/bolt/threadid/task_tied_thread_threadid.c
@@ -1,0 +1,103 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include <string.h>
+#include <stdio.h>
+
+int test_task_tied_thread_threadid(int num_threads) {
+  int vals[num_threads];
+  memset(vals, 0, sizeof(int) * num_threads);
+  omp_set_max_active_levels(2);
+
+  #pragma omp parallel num_threads(num_threads / 2 + 1)
+  #pragma omp master
+  {
+    int i;
+    for (i = 0; i < num_threads; i++) {
+      #pragma omp task firstprivate(i)
+      {
+        int omp_thread_id = omp_get_thread_num();
+        ABT_thread abt_thread;
+        ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread));
+
+        int local_vals[num_threads];
+        memset(local_vals, 0, sizeof(int) * num_threads);
+
+        int j;
+        #pragma omp parallel for num_threads(num_threads)
+        for (j = 0; j < num_threads; j++) {
+          int l2_omp_thread_id = omp_get_thread_num();
+          ABT_thread l2_abt_thread;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&l2_abt_thread));
+
+          // Context switching in OpenMP.
+          #pragma omp taskyield
+
+          int l2_omp_thread_id2 = omp_get_thread_num();
+          if (l2_omp_thread_id == l2_omp_thread_id2) {
+            local_vals[j] += 1;
+          }
+          ABT_thread l2_abt_thread2;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&l2_abt_thread2));
+          ABT_bool l2_abt_thread_equal;
+          ABT_EXIT_IF_FAIL(ABT_thread_equal(l2_abt_thread, l2_abt_thread2,
+                                            &l2_abt_thread_equal));
+          if (l2_abt_thread_equal == ABT_TRUE) {
+            local_vals[j] += 2;
+          }
+
+          // Context switching in Argobots.
+          ABT_EXIT_IF_FAIL(ABT_thread_yield());
+
+          int l2_omp_thread_id3 = omp_get_thread_num();
+          if (l2_omp_thread_id2 == l2_omp_thread_id3) {
+            local_vals[j] += 4;
+          }
+        }
+
+        // Check child threads.
+        int child_fail = 0;
+        for (j = 0; j < num_threads; j++) {
+          if (local_vals[i] != 7) {
+            child_fail = 1;
+          }
+        }
+        if (!child_fail) {
+          vals[i] += 1;
+        }
+
+        int omp_thread_id2 = omp_get_thread_num();
+        if (omp_thread_id == omp_thread_id2) {
+          vals[i] += 2;
+        }
+        ABT_thread abt_thread2;
+        ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));
+        ABT_bool abt_thread_equal;
+        ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,
+                                          &abt_thread_equal));
+        if (abt_thread_equal == ABT_TRUE) {
+          vals[i] += 4;
+        }
+      }
+    }
+  }
+
+  int index;
+  for (index = 0; index < num_threads; index++) {
+    if (vals[index] != 7) {
+      printf("vals[%d] == %d\n", index, vals[index]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_task_tied_thread_threadid(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/task_tied_threadid.c
+++ b/runtime/test/bolt/threadid/task_tied_threadid.c
@@ -1,0 +1,67 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include <string.h>
+#include <stdio.h>
+
+int test_task_tied_threadid(int num_threads) {
+  int i, vals[NUM_TASKS];
+  memset(vals, 0, sizeof(vals));
+
+  #pragma omp parallel num_threads(num_threads)
+  {
+    #pragma omp master
+    {
+      for (i = 0; i < NUM_TASKS; i++) {
+        #pragma omp task firstprivate(i)
+        {
+          int omp_thread_id = omp_get_thread_num();
+          ABT_thread abt_thread;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread));
+
+          // Context switching in OpenMP.
+          #pragma omp taskyield
+
+          int omp_thread_id2 = omp_get_thread_num();
+          if (omp_thread_id == omp_thread_id2) {
+            vals[i] += 1;
+          }
+          ABT_thread abt_thread2;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));
+          ABT_bool abt_thread_equal;
+          ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,
+                                            &abt_thread_equal));
+          if (abt_thread_equal == ABT_TRUE) {
+            vals[i] += 2;
+          }
+
+          // Context switching in Argobots.
+          ABT_EXIT_IF_FAIL(ABT_thread_yield());
+
+          int omp_thread_id3 = omp_get_thread_num();
+          if (omp_thread_id2 == omp_thread_id3) {
+            vals[i] += 4;
+          }
+        }
+      }
+    }
+  }
+
+  for (i = 0; i < NUM_TASKS; i++) {
+    if (vals[i] != 7) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_task_tied_threadid(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/task_unitied_thread_threadid.c
+++ b/runtime/test/bolt/threadid/task_unitied_thread_threadid.c
@@ -1,0 +1,98 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include <string.h>
+#include <stdio.h>
+
+int test_task_untied_thread_threadid(int num_threads) {
+  int vals[num_threads];
+  memset(vals, 0, sizeof(int) * num_threads);
+  omp_set_max_active_levels(2);
+
+  #pragma omp parallel num_threads(num_threads / 2 + 1)
+  #pragma omp master
+  {
+    int i;
+    for (i = 0; i < num_threads; i++) {
+      #pragma omp task firstprivate(i) untied
+      {
+        ABT_thread abt_thread;
+        ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread));
+
+        int local_vals[num_threads];
+        memset(local_vals, 0, sizeof(int) * num_threads);
+
+        int j;
+        #pragma omp parallel for num_threads(num_threads)
+        for (j = 0; j < num_threads; j++) {
+          int l2_omp_thread_id = omp_get_thread_num();
+          ABT_thread l2_abt_thread;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&l2_abt_thread));
+
+          // Context switching in OpenMP.
+          #pragma omp taskyield
+
+          int l2_omp_thread_id2 = omp_get_thread_num();
+          if (l2_omp_thread_id == l2_omp_thread_id2) {
+            local_vals[j] += 1;
+          }
+          ABT_thread l2_abt_thread2;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&l2_abt_thread2));
+          ABT_bool l2_abt_thread_equal;
+          ABT_EXIT_IF_FAIL(ABT_thread_equal(l2_abt_thread, l2_abt_thread2,
+                                            &l2_abt_thread_equal));
+          if (l2_abt_thread_equal == ABT_TRUE) {
+            local_vals[j] += 2;
+          }
+
+          // Context switching in Argobots.
+          ABT_EXIT_IF_FAIL(ABT_thread_yield());
+
+          int l2_omp_thread_id3 = omp_get_thread_num();
+          if (l2_omp_thread_id2 == l2_omp_thread_id3) {
+            local_vals[j] += 4;
+          }
+        }
+
+        // Check child threads.
+        int child_fail = 0;
+        for (j = 0; j < num_threads; j++) {
+          if (local_vals[i] != 7) {
+            child_fail = 1;
+          }
+        }
+        if (!child_fail) {
+          vals[i] += 1;
+        }
+
+        ABT_thread abt_thread2;
+        ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));
+        ABT_bool abt_thread_equal;
+        ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,
+                                          &abt_thread_equal));
+        if (abt_thread_equal == ABT_TRUE) {
+          vals[i] += 2;
+        }
+      }
+    }
+  }
+
+  int index;
+  for (index = 0; index < num_threads; index++) {
+    if (vals[index] != 3) {
+      printf("vals[%d] == %d\n", index, vals[index]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_task_untied_thread_threadid(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/task_untied_threadid.c
+++ b/runtime/test/bolt/threadid/task_untied_threadid.c
@@ -1,0 +1,67 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt && !clang
+
+// Clang 10.0 discards local variables saved before taskyield.  We mark untied
+// task tests that use local variables with Clang as unsupported so far.
+#include "omp_testsuite.h"
+#include <string.h>
+#include <stdio.h>
+
+int test_task_untied_threadid(int num_threads) {
+  int i, vals[NUM_TASKS];
+  memset(vals, 0, sizeof(vals));
+
+  #pragma omp parallel num_threads(num_threads)
+  {
+    #pragma omp master
+    {
+      for (i = 0; i < NUM_TASKS; i++) {
+        #pragma omp task firstprivate(i) untied
+        {
+          ABT_thread abt_thread;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread));
+
+          // Context switching in OpenMP.
+          #pragma omp taskyield
+
+          int omp_thread_id2 = omp_get_thread_num();
+          ABT_thread abt_thread2;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));
+          ABT_bool abt_thread_equal;
+          ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,
+                                            &abt_thread_equal));
+          if (abt_thread_equal == ABT_TRUE) {
+            vals[i] += 1;
+          }
+
+          // Context switching in Argobots.
+          ABT_EXIT_IF_FAIL(ABT_thread_yield());
+
+          int omp_thread_id3 = omp_get_thread_num();
+          if (omp_thread_id2 == omp_thread_id3) {
+            // Argobots context switch does not change the thread-task mapping.
+            vals[i] += 2;
+          }
+        }
+      }
+    }
+  }
+
+  for (i = 0; i < NUM_TASKS; i++) {
+    if (vals[i] != 3) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_task_untied_threadid(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/task_untied_threadid2.c
+++ b/runtime/test/bolt/threadid/task_untied_threadid2.c
@@ -1,0 +1,65 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include <string.h>
+#include <stdio.h>
+
+int test_task_untied_threadid2(int num_threads) {
+  int i, vals[NUM_TASKS];
+  ABT_thread abt_threads[NUM_TASKS];
+  memset(vals, 0, sizeof(vals));
+
+  #pragma omp parallel num_threads(num_threads)
+  {
+    #pragma omp master
+    {
+      for (i = 0; i < NUM_TASKS; i++) {
+        #pragma omp task firstprivate(i) untied
+        {
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_threads[i]));
+
+          // Context switching in OpenMP.
+          #pragma omp taskyield
+
+          int omp_thread_id2 = omp_get_thread_num();
+          ABT_thread abt_thread = abt_threads[i];
+          ABT_thread abt_thread2;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));
+          ABT_bool abt_thread_equal;
+          ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,
+                                            &abt_thread_equal));
+          if (abt_thread_equal == ABT_TRUE) {
+            vals[i] += 1;
+          }
+
+          // Context switching in Argobots.
+          ABT_EXIT_IF_FAIL(ABT_thread_yield());
+
+          int omp_thread_id3 = omp_get_thread_num();
+          if (omp_thread_id2 == omp_thread_id3) {
+            // Argobots context switch does not change the thread-task mapping.
+            vals[i] += 2;
+          }
+        }
+      }
+    }
+  }
+
+  for (i = 0; i < NUM_TASKS; i++) {
+    if (vals[i] != 3) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_task_untied_threadid2(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/taskdep_tied_threadid.c
+++ b/runtime/test/bolt/threadid/taskdep_tied_threadid.c
@@ -1,0 +1,142 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+#define TASK_TIED_CHECK(_val_index)                                            \
+  do {                                                                         \
+    int val_index = (_val_index);                                              \
+    int omp_thread_id = omp_get_thread_num();                                  \
+    ABT_thread abt_thread;                                                     \
+    ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread));                            \
+                                                                               \
+    _Pragma("omp taskyield")                                                   \
+                                                                               \
+    int omp_thread_id2 = omp_get_thread_num();                                 \
+    if (omp_thread_id == omp_thread_id2) {                                     \
+      vals[val_index] += 1;                                                    \
+    }                                                                          \
+    ABT_thread abt_thread2;                                                    \
+    ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));                           \
+    ABT_bool abt_thread_equal;                                                 \
+    ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,                 \
+                                      &abt_thread_equal));                     \
+    if (abt_thread_equal == ABT_TRUE) {                                        \
+      vals[val_index] += 2;                                                    \
+    }                                                                          \
+                                                                               \
+    ABT_EXIT_IF_FAIL(ABT_thread_yield());                                      \
+                                                                               \
+    int omp_thread_id3 = omp_get_thread_num();                                 \
+    if (omp_thread_id2 == omp_thread_id3) {                                    \
+      vals[val_index] += 4;                                                    \
+    }                                                                          \
+  } while (0)
+
+int test_taskdep_tied_threadid(int num_threads) {
+  int n = 10;
+  int seq_val, task_val;
+
+  int vals[n * n];
+  memset(vals, 0, sizeof(int) * n * n);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(num_threads)
+  #pragma omp master
+  {
+    int i, j;
+    int *A_buf = (int *)malloc(sizeof(int) * n * n);
+    int **A = (int **)malloc(sizeof(int *) * n);
+    for(i = 0; i < n; i++) {
+      A[i] = A_buf + (i * n);
+      for(j = 0; j < n; j++) {
+        // Assign random values.
+        A[i][j] = i * n + j;
+      }
+    }
+    // A[i][j] is the root task.
+    for(i = 0; i < n; i++) {
+      for(j = 0; j < n; j++) {
+        if (i == 0 && j == 0) {
+          #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j)
+          {
+            TASK_TIED_CHECK(i * n + j);
+            A[i][j] = 1;
+          }
+        } else if (i == 0) {
+          #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                           firstprivate(A, i, j)
+          {
+            TASK_TIED_CHECK(i * n + j);
+            A[i][j] = A[i][j - 1];
+          }
+        } else if (j == 0) {
+          #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                           firstprivate(A, i, j)
+          {
+            TASK_TIED_CHECK(i * n + j);
+            A[i][j] = A[i - 1][j];
+          }
+        } else {
+          #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                           depend(out:A[i][j])
+          {
+            TASK_TIED_CHECK(i * n + j);
+            A[i][j] = A[i - 1][j] + A[i][j - 1];
+          }
+        }
+      }
+    }
+    #pragma omp taskwait
+    task_val = A[n - 1][n - 1];
+    free(A);
+    free(A_buf);
+  }
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("[%d] Failed: route(%d) = %d (ANS = %d)\n", num_threads, n, task_val,
+           seq_val);
+    return 0;
+  }
+  int index;
+  for (index = 0; index < n * n; index++) {
+    if (vals[index] != 7) {
+      printf("vals[%d] == %d\n", index, vals[index]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i;
+  int num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_tied_threadid(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/taskdep_untied_threadid.c
+++ b/runtime/test/bolt/threadid/taskdep_untied_threadid.c
@@ -1,0 +1,142 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt && !clang
+
+// Clang 10.0 discards local variables saved before taskyield.  We mark untied
+// task tests that use local variables across taskyield with Clang as
+// unsupported so far.
+#include "omp_testsuite.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+#define TASK_UNTIED_CHECK(_val_index)                                          \
+  do {                                                                         \
+    int val_index = (_val_index);                                              \
+    ABT_thread abt_thread;                                                     \
+    ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread));                            \
+                                                                               \
+    _Pragma("omp taskyield")                                                   \
+                                                                               \
+    int omp_thread_id2 = omp_get_thread_num();                                 \
+    ABT_thread abt_thread2;                                                    \
+    ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));                           \
+    ABT_bool abt_thread_equal;                                                 \
+    ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,                 \
+                                      &abt_thread_equal));                     \
+    if (abt_thread_equal == ABT_TRUE) {                                        \
+      vals[val_index] += 1;                                                    \
+    }                                                                          \
+                                                                               \
+    ABT_EXIT_IF_FAIL(ABT_thread_yield());                                      \
+                                                                               \
+    int omp_thread_id3 = omp_get_thread_num();                                 \
+    if (omp_thread_id2 == omp_thread_id3) {                                    \
+      vals[val_index] += 2;                                                    \
+    }                                                                          \
+  } while (0)
+
+int test_taskdep_untied_threadid(int num_threads) {
+  int n = 10;
+  int seq_val, task_val;
+
+  int vals[n * n];
+  memset(vals, 0, sizeof(int) * n * n);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(num_threads)
+  #pragma omp master
+  {
+    int i, j;
+    int *A_buf = (int *)malloc(sizeof(int) * n * n);
+    int **A = (int **)malloc(sizeof(int *) * n);
+    for(i = 0; i < n; i++) {
+      A[i] = A_buf + (i * n);
+      for(j = 0; j < n; j++) {
+        // Assign random values.
+        A[i][j] = i * n + j;
+      }
+    }
+    // A[i][j] is the root task.
+    for(i = 0; i < n; i++) {
+      for(j = 0; j < n; j++) {
+        if (i == 0 && j == 0) {
+          #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j) untied
+          {
+            TASK_UNTIED_CHECK(i * n + j);
+            A[i][j] = 1;
+          }
+        } else if (i == 0) {
+          #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                           firstprivate(A, i, j) untied
+          {
+            TASK_UNTIED_CHECK(i * n + j);
+            A[i][j] = A[i][j - 1];
+          }
+        } else if (j == 0) {
+          #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                           firstprivate(A, i, j) untied
+          {
+            TASK_UNTIED_CHECK(i * n + j);
+            A[i][j] = A[i - 1][j];
+          }
+        } else {
+          #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                           depend(out:A[i][j]) untied
+          {
+            TASK_UNTIED_CHECK(i * n + j);
+            A[i][j] = A[i - 1][j] + A[i][j - 1];
+          }
+        }
+      }
+    }
+    #pragma omp taskwait
+    task_val = A[n - 1][n - 1];
+    free(A);
+    free(A_buf);
+  }
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("[%d] Failed: route(%d) = %d (ANS = %d)\n", num_threads, n, task_val,
+           seq_val);
+    return 0;
+  }
+  int index;
+  for (index = 0; index < n * n; index++) {
+    if (vals[index] != 3) {
+      printf("vals[%d] == %d\n", index, vals[index]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i;
+  int num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_untied_threadid(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/taskdep_untied_threadid2.c
+++ b/runtime/test/bolt/threadid/taskdep_untied_threadid2.c
@@ -1,0 +1,138 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int calc_seq(int n) {
+  int i, j, *buffer = (int *)malloc(sizeof(int) * n * n);
+  for (i = 0; i < n; i++) {
+    for (j = 0; j < n; j++) {
+      if (i == 0 && j == 0) {
+        buffer[i * n + j] = 1;
+      } else if (i == 0) {
+        buffer[i * n + j] = buffer[i * n + (j - 1)];
+      } else if (j == 0) {
+        buffer[i * n + j] = buffer[(i - 1) * n + j];
+      } else {
+        buffer[i * n + j] = buffer[(i - 1) * n + j] + buffer[i * n + (j - 1)];
+      }
+    }
+  }
+  int ret = buffer[(n - 1) * n + (n - 1)];
+  free(buffer);
+  return ret;
+}
+
+#define TASK_UNTIED_CHECK(val_index)                                           \
+  do {                                                                         \
+    ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_threads[(val_index)]));              \
+                                                                               \
+    _Pragma("omp taskyield")                                                   \
+                                                                               \
+    ABT_thread abt_thread = abt_threads[(val_index)];                          \
+    int omp_thread_id2 = omp_get_thread_num();                                 \
+    ABT_thread abt_thread2;                                                    \
+    ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));                           \
+    ABT_bool abt_thread_equal;                                                 \
+    ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,                 \
+                                      &abt_thread_equal));                     \
+    if (abt_thread_equal == ABT_TRUE) {                                        \
+      vals[(val_index)] += 1;                                                  \
+    }                                                                          \
+                                                                               \
+    ABT_EXIT_IF_FAIL(ABT_thread_yield());                                      \
+                                                                               \
+    int omp_thread_id3 = omp_get_thread_num();                                 \
+    if (omp_thread_id2 == omp_thread_id3) {                                    \
+      vals[(val_index)] += 2;                                                  \
+    }                                                                          \
+  } while (0)
+
+int test_taskdep_untied_threadid2(int num_threads) {
+  int n = 10;
+  int seq_val, task_val;
+
+  int vals[n * n];
+  ABT_thread abt_threads[n * n];
+  memset(vals, 0, sizeof(int) * n * n);
+
+  #pragma omp parallel shared(task_val) firstprivate(n) num_threads(num_threads)
+  #pragma omp master
+  {
+    int i, j;
+    int *A_buf = (int *)malloc(sizeof(int) * n * n);
+    int **A = (int **)malloc(sizeof(int *) * n);
+    for(i = 0; i < n; i++) {
+      A[i] = A_buf + (i * n);
+      for(j = 0; j < n; j++) {
+        // Assign random values.
+        A[i][j] = i * n + j;
+      }
+    }
+    // A[i][j] is the root task.
+    for(i = 0; i < n; i++) {
+      for(j = 0; j < n; j++) {
+        if (i == 0 && j == 0) {
+          #pragma omp task depend(out:A[i][j]) firstprivate(A, i, j) untied
+          {
+            TASK_UNTIED_CHECK(i * n + j);
+            A[i][j] = 1;
+          }
+        } else if (i == 0) {
+          #pragma omp task depend(in:A[i][j - 1]) depend(out:A[i][j]) \
+                           firstprivate(A, i, j) untied
+          {
+            TASK_UNTIED_CHECK(i * n + j);
+            A[i][j] = A[i][j - 1];
+          }
+        } else if (j == 0) {
+          #pragma omp task depend(in:A[i - 1][j]) depend(out:A[i][j]) \
+                           firstprivate(A, i, j) untied
+          {
+            TASK_UNTIED_CHECK(i * n + j);
+            A[i][j] = A[i - 1][j];
+          }
+        } else {
+          #pragma omp task depend(in:A[i - 1][j], A[i][j - 1]) \
+                           depend(out:A[i][j]) untied
+          {
+            TASK_UNTIED_CHECK(i * n + j);
+            A[i][j] = A[i - 1][j] + A[i][j - 1];
+          }
+        }
+      }
+    }
+    #pragma omp taskwait
+    task_val = A[n - 1][n - 1];
+    free(A);
+    free(A_buf);
+  }
+
+  seq_val = calc_seq(n);
+  if(seq_val != task_val) {
+    printf("[%d] Failed: route(%d) = %d (ANS = %d)\n", num_threads, n, task_val,
+           seq_val);
+    return 0;
+  }
+  int index;
+  for (index = 0; index < n * n; index++) {
+    if (vals[index] != 3) {
+      printf("vals[%d] == %d\n", index, vals[index]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i;
+  int num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskdep_untied_threadid2(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/taskloop_tied_threadid.c
+++ b/runtime/test/bolt/threadid/taskloop_tied_threadid.c
@@ -1,0 +1,67 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include <string.h>
+#include <stdio.h>
+
+int test_taskloop_tied_threadid(int num_threads) {
+  int vals[NUM_TASKS];
+  memset(vals, 0, sizeof(vals));
+
+  #pragma omp parallel num_threads(num_threads)
+  {
+    #pragma omp master
+    {
+      int i;
+      #pragma omp taskloop grainsize(1)
+      for (i = 0; i < NUM_TASKS; i++) {
+        {
+          ABT_thread abt_thread;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread));
+
+          // Context switching in OpenMP.
+          #pragma omp taskyield
+
+          int omp_thread_id2 = omp_get_thread_num();
+          ABT_thread abt_thread2;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));
+          ABT_bool abt_thread_equal;
+          ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,
+                                            &abt_thread_equal));
+          if (abt_thread_equal == ABT_TRUE) {
+            vals[i] += 1;
+          }
+
+          // Context switching in Argobots.
+          ABT_EXIT_IF_FAIL(ABT_thread_yield());
+
+          int omp_thread_id3 = omp_get_thread_num();
+          if (omp_thread_id2 == omp_thread_id3) {
+            // Argobots context switch does not change the thread-task mapping.
+            vals[i] += 2;
+          }
+        }
+      }
+    }
+  }
+
+  int index;
+  for (index = 0; index < NUM_TASKS; index++) {
+    if (vals[index] != 3) {
+      printf("vals[%d] == %d\n", index, vals[index]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i;
+  int num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskloop_tied_threadid(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/taskloop_untied_threadid.c
+++ b/runtime/test/bolt/threadid/taskloop_untied_threadid.c
@@ -1,0 +1,70 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt && !clang
+
+// Clang 10.0 seems ignoring the taskloop's "untied" attribute.
+// We mark taskloop + untied with Clang as unsupported so far.
+#include "omp_testsuite.h"
+#include <string.h>
+#include <stdio.h>
+
+int test_taskloop_untied_threadid(int num_threads) {
+  int vals[NUM_TASKS];
+  memset(vals, 0, sizeof(vals));
+
+  #pragma omp parallel num_threads(num_threads)
+  {
+    #pragma omp master
+    {
+      int i;
+      #pragma omp taskloop grainsize(1) untied
+      for (i = 0; i < NUM_TASKS; i++) {
+        {
+          ABT_thread abt_thread;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread));
+
+          // Context switching in OpenMP.
+          #pragma omp taskyield
+
+          int omp_thread_id2 = omp_get_thread_num();
+          ABT_thread abt_thread2;
+          ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));
+          ABT_bool abt_thread_equal;
+          ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,
+                                            &abt_thread_equal));
+          if (abt_thread_equal == ABT_TRUE) {
+            vals[i] += 1;
+          }
+
+          // Context switching in Argobots.
+          ABT_EXIT_IF_FAIL(ABT_thread_yield());
+
+          int omp_thread_id3 = omp_get_thread_num();
+          if (omp_thread_id2 == omp_thread_id3) {
+            // Argobots context switch does not change the thread-task mapping.
+            vals[i] += 2;
+          }
+        }
+      }
+    }
+  }
+
+  int index;
+  for (index = 0; index < NUM_TASKS; index++) {
+    if (vals[index] != 3) {
+      printf("vals[%d] == %d\n", index, vals[index]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i;
+  int num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_taskloop_untied_threadid(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/thread_thread_threadid.c
+++ b/runtime/test/bolt/threadid/thread_thread_threadid.c
@@ -1,0 +1,95 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include <string.h>
+#include <stdio.h>
+
+int test_thread_thread_threadid(int num_threads) {
+  int i, vals[num_threads];
+  memset(vals, 0, sizeof(int) * num_threads);
+  omp_set_max_active_levels(2);
+
+  #pragma omp parallel for num_threads(num_threads)
+  for (i = 0; i < num_threads; i++) {
+    int omp_thread_id = omp_get_thread_num();
+    ABT_thread abt_thread;
+    ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread));
+
+    int local_vals[num_threads];
+    memset(local_vals, 0, sizeof(int) * num_threads);
+
+    int j;
+    #pragma omp parallel for num_threads(num_threads)
+    for (j = 0; j < num_threads; j++) {
+      int l2_omp_thread_id = omp_get_thread_num();
+      ABT_thread l2_abt_thread;
+      ABT_EXIT_IF_FAIL(ABT_thread_self(&l2_abt_thread));
+
+      // Context switching in OpenMP.
+      #pragma omp taskyield
+
+      int l2_omp_thread_id2 = omp_get_thread_num();
+      if (l2_omp_thread_id == l2_omp_thread_id2) {
+        local_vals[j] += 1;
+      }
+      ABT_thread l2_abt_thread2;
+      ABT_EXIT_IF_FAIL(ABT_thread_self(&l2_abt_thread2));
+      ABT_bool l2_abt_thread_equal;
+      ABT_EXIT_IF_FAIL(ABT_thread_equal(l2_abt_thread, l2_abt_thread2,
+                                        &l2_abt_thread_equal));
+      if (l2_abt_thread_equal == ABT_TRUE) {
+        local_vals[j] += 2;
+      }
+
+      // Context switching in Argobots.
+      ABT_EXIT_IF_FAIL(ABT_thread_yield());
+
+      int l2_omp_thread_id3 = omp_get_thread_num();
+      if (l2_omp_thread_id2 == l2_omp_thread_id3) {
+        local_vals[j] += 4;
+      }
+    }
+
+    // Check child threads.
+    int child_fail = 0;
+    for (j = 0; j < num_threads; j++) {
+      if (local_vals[i] != 7) {
+        child_fail = 1;
+      }
+    }
+    if (!child_fail) {
+      vals[i] += 1;
+    }
+
+    int omp_thread_id2 = omp_get_thread_num();
+    if (omp_thread_id == omp_thread_id2) {
+      vals[i] += 2;
+    }
+    ABT_thread abt_thread2;
+    ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));
+    ABT_bool abt_thread_equal;
+    ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,
+                                      &abt_thread_equal));
+    if (abt_thread_equal == ABT_TRUE) {
+      vals[i] += 4;
+    }
+  }
+
+  for (i = 0; i < num_threads; i++) {
+    if (vals[i] != 7) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_thread_thread_threadid(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/bolt/threadid/thread_threadid.c
+++ b/runtime/test/bolt/threadid/thread_threadid.c
@@ -1,0 +1,61 @@
+// RUN: %libomp-compile-and-run
+// REQUIRES: abt
+#include "omp_testsuite.h"
+#include <string.h>
+#include <stdio.h>
+
+int test_thread_threadid(int num_threads) {
+  int i, vals[num_threads];
+  memset(vals, 0, sizeof(int) * num_threads);
+
+  #pragma omp parallel for num_threads(num_threads)
+  for (i = 0; i < num_threads; i++) {
+    int omp_thread_id = omp_get_thread_num();
+    ABT_thread abt_thread;
+    ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread));
+
+    // Context switching in OpenMP.
+    #pragma omp taskyield
+
+    int omp_thread_id2 = omp_get_thread_num();
+    if (omp_thread_id == omp_thread_id2) {
+      vals[i] += 1;
+    }
+    ABT_thread abt_thread2;
+    ABT_EXIT_IF_FAIL(ABT_thread_self(&abt_thread2));
+    ABT_bool abt_thread_equal;
+    ABT_EXIT_IF_FAIL(ABT_thread_equal(abt_thread, abt_thread2,
+                                      &abt_thread_equal));
+    if (abt_thread_equal == ABT_TRUE) {
+      vals[i] += 2;
+    }
+
+
+    // Context switching in Argobots.
+    ABT_EXIT_IF_FAIL(ABT_thread_yield());
+
+    int omp_thread_id3 = omp_get_thread_num();
+    if (omp_thread_id2 == omp_thread_id3) {
+      // Argobots context switch does not change the underlying thread.
+      vals[i] += 4;
+    }
+  }
+
+  for (i = 0; i < num_threads; i++) {
+    if (vals[i] != 7) {
+      printf("vals[%d] == %d\n", i, vals[i]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int main() {
+  int i, num_failed = 0;
+  for (i = 0; i < REPETITIONS; i++) {
+    if (!test_thread_threadid(i + 1)) {
+      num_failed++;
+    }
+  }
+  return num_failed;
+}

--- a/runtime/test/omp_testsuite.h
+++ b/runtime/test/omp_testsuite.h
@@ -79,7 +79,13 @@ static int pthread_join(pthread_t thread, void **retval) {
 #ifdef BOLT_VERSION
 #  if BOLT_THREAD == BOLT_THREAD_ARGOBOTS
 #    include <abt.h>
-#    define THREAD_SCHED_POINT() ABT_thread_yield()
+#    define ABT_EXIT_IF_FAIL(_abt_call)                                        \
+        do {                                                                   \
+          int _abt_ret = (_abt_call);                                          \
+          if (_abt_ret != ABT_SUCCESS)                                         \
+            exit(1);                                                           \
+        } while (0)
+#    define THREAD_SCHED_POINT() ABT_EXIT_IF_FAIL(ABT_thread_yield())
 #  else
 #    define THREAD_SCHED_POINT() do {;} while(0)
 #  endif


### PR DESCRIPTION
This PR adds a few tests that are specific to BOLT; for example, these tests check bugs reported in BOLT, Argobots interoperability, and BOLT-specific thread/task mapping and scheduling.

This PR also creates a test for a bug reported in #49.

Note that some tests are marked as unsupported with certain compilers (especially regarding untied tasks) mainly because of, to our best knowledge, compiler issues. They should be fixed once we understand the problems properly.  