### PR TITLE
Fix untied task

### DIFF
--- a/runtime/src/kmp.h
+++ b/runtime/src/kmp.h
@@ -3660,7 +3660,8 @@ extern void __kmp_abt_global_destroy(void);
 extern void __kmp_abt_create_uber(int gtid, kmp_info_t *th, size_t stack_size);
 extern void __kmp_abt_join_workers(kmp_team_t *team);
 extern int __kmp_abt_create_task(kmp_info_t *th, kmp_task_t *task);
-extern void __kmp_abt_wait_child_tasks(kmp_info_t *th, int yield);
+extern kmp_info_t *__kmp_abt_wait_child_tasks(kmp_info_t *th, bool thread_bind,
+                                              int yield);
 extern kmp_info_t *__kmp_abt_bind_task_to_thread(kmp_team_t *team,
                                                  kmp_taskdata_t *taskdata);
 extern void __kmp_abt_set_self_info(kmp_info_t *th);

--- a/runtime/src/kmp_barrier.cpp
+++ b/runtime/src/kmp_barrier.cpp
@@ -2148,7 +2148,7 @@ int __kmp_barrier(enum barrier_type bt, int gtid, int is_split,
                 gtid, __kmp_team_from_gtid(gtid)->t.t_id,
                 __kmp_tid_from_gtid(gtid)));
   // Complete and free all child tasks.
-  __kmp_abt_wait_child_tasks(this_thr, FALSE);
+  __kmp_abt_wait_child_tasks(this_thr, true, FALSE);
   if (!team->t.t_serialized) {
     KMP_MB();
     kmp_taskdata_t *taskdata = this_thr->th.th_current_task;

--- a/runtime/src/kmp_runtime.cpp
+++ b/runtime/src/kmp_runtime.cpp
@@ -5636,7 +5636,7 @@ void __kmp_free_team(kmp_root_t *root,
       for (f = 1; f < team->t.t_nproc; ++f) {
         KMP_DEBUG_ASSERT(team->t.t_threads[f]);
         kmp_info_t *th = team->t.t_threads[f];
-        __kmp_abt_wait_child_tasks(th, 0);
+        __kmp_abt_wait_child_tasks(th, true, 0);
         // Now it is safe to reap this thread.
         th->th.th_reap_state = KMP_SAFE_TO_REAP;
       }
@@ -7622,7 +7622,7 @@ void __kmp_internal_join(ident_t *id, int gtid, kmp_team_t *team) {
 #if KMP_USE_ABT
   {
     /* The master thread executes the remaining tasks*/
-    __kmp_abt_wait_child_tasks(this_thr, FALSE);
+    __kmp_abt_wait_child_tasks(this_thr, true, FALSE);
 
     kmp_taskdata_t *taskdata = this_thr->th.th_current_task;
 

--- a/runtime/src/kmp_tasking.cpp
+++ b/runtime/src/kmp_tasking.cpp
@@ -1844,7 +1844,7 @@ static kmp_int32 __kmpc_omp_taskwait_template(ident_t *loc_ref, kmp_int32 gtid,
 #if KMP_USE_ABT
 
   thread = __kmp_threads[gtid];
-  __kmp_abt_wait_child_tasks(thread, TRUE);
+  __kmp_abt_wait_child_tasks(thread, true, TRUE);
 
   KA_TRACE(10, ("__kmpc_omp_taskwait(exit): T#%d finished waiting, "
                 "returning TASK_CURRENT_NOT_QUEUED\n", gtid));
@@ -2558,7 +2558,7 @@ void __kmpc_end_taskgroup(ident_t *loc, int gtid) {
         (thread->th.th_task_team != NULL &&
          thread->th.th_task_team->tt.tt_found_proxy_tasks)) {
 #if KMP_USE_ABT
-      __kmp_abt_wait_child_tasks(thread, 0);
+      __kmp_abt_wait_child_tasks(thread, true, 0);
       // Since BOLT manages tasks by task queue owned by every task,
       // taskgroup->count is not modified at the end of tasks.
       // FIXME: it assumes parent-child relationship between parent tasks and


### PR DESCRIPTION
This patch fixes support for untied tasks, which has not been covered by #55. This happens only when a task is untied; on waiting child tasks, an untied task releases its thread-task binding, which breaks internal runtime logic that assumes the same underlying thread across function calls. This PR addresses it by binding a thread and a task even if a task is untied in such a case.

Note that, strictly speaking, this patch limits the freedom of scheduling. The OpenMP specification allows another OpenMP thread to execute an untied task at any scheduling point, while this patch disables such scheduling at certain types of scheduling points. For example, the associated thread before and after `taskwait` is unchanged even if an untied task is used. This fix would be our future work (if one really cares).

I note that this PR fixes several failures reported in #69.
