### PR TITLE
[BOLT] change the URL for bug report

### DIFF
--- a/runtime/src/i18n/en_US.txt
+++ b/runtime/src/i18n/en_US.txt
@@ -440,7 +440,7 @@ SubmitBugReport              "Please submit a bug report with this message, comp
                              "compiler and operating system versions. Faster response will be "
                              "obtained by including all program sources. For information on "
                              "submitting this issue, please see "
-                             "https://bugs.llvm.org/."
+                             "https://www.bolt-omp.org/."
 OBSOLETE                     "Check NLSPATH environment variable, its value is \"%1$s\"."
 ChangeStackLimit             "Please try changing the shell stack limit or adjusting the "
                              "OMP_STACKSIZE environment variable."


### PR DESCRIPTION
When BOLT encounters a bug, BOLT should show the URL of the BOLT project (http://www.bolt-omp.org), not that of LLVM OpenMP (https://bugs.llvm.org/) in order to avoid confusion.