### PR TITLE
[CI] rename a build job of GitHub CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build-mpich:
+  build-bolt:
 
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
I have not changed the name of a build job by mistake. This patch fixes it.