### PR TITLE
update test support

### DIFF
--- a/runtime/test/misc_bugs/stack-propagate.c
+++ b/runtime/test/misc_bugs/stack-propagate.c
@@ -1,4 +1,5 @@
 // RUN: %libomp-compile-and-run
+// UNSUPPORTED: abt
 
 // https://bugs.llvm.org/show_bug.cgi?id=26540 requested
 // stack size to be propagated from master to workers.

--- a/runtime/test/ompt/teams/parallel_team.c
+++ b/runtime/test/ompt/teams/parallel_team.c
@@ -1,6 +1,6 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
-// UNSUPPORTED: gcc
+// UNSUPPORTED: gcc, icc-19
 #include "callback.h"
 
 int main() {

--- a/runtime/test/ompt/teams/serial_teams.c
+++ b/runtime/test/ompt/teams/serial_teams.c
@@ -1,6 +1,6 @@
 // RUN: %libomp-compile-and-run | %sort-threads | FileCheck %s
 // REQUIRES: ompt
-// UNSUPPORTED: gcc
+// UNSUPPORTED: gcc, icc-19
 #include "callback.h"
 
 int main() {

--- a/runtime/test/ompt/teams/serialized.c
+++ b/runtime/test/ompt/teams/serialized.c
@@ -1,6 +1,6 @@
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
-// UNSUPPORTED: gcc
+// UNSUPPORTED: gcc, icc-19
 #include "callback.h"
 
 int main() {

--- a/runtime/test/ompt/teams/team.c
+++ b/runtime/test/ompt/teams/team.c
@@ -1,6 +1,6 @@
 // RUN: %libomp-compile-and-run | FileCheck %s
 // REQUIRES: ompt
-// UNSUPPORTED: gcc
+// UNSUPPORTED: gcc, icc-19
 #include "callback.h"
 
 int main() {


### PR DESCRIPTION
This PR updates the supported tests:
- `runtime/test/misc_bugs/stack-propagate.c`
 The stack size of Argobots does not come from `getrlimit()`, which causes an error. This test is skipped if Argobots is used.
- `runtime/test/ompt/teams/*.c`
 In some ICC environments `libcoi_device.so`, which causes an error. These tests are skipped if Argobots is used.
 