### PR TITLE
fix omptarget-nvptx tests

### DIFF
--- a/libomptarget/deviceRTLs/nvptx/CMakeLists.txt
+++ b/libomptarget/deviceRTLs/nvptx/CMakeLists.txt
@@ -199,7 +199,7 @@ if(LIBOMPTARGET_DEP_CUDA_FOUND)
       # Copy library to destination.
       add_custom_command(TARGET bolt-omptarget-nvptx-${sm}-bc POST_BUILD
                          COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-nvptx-sm_${sm}.bc
-                         $<TARGET_FILE_DIR:omptarget-nvptx>)
+                         $<TARGET_FILE_DIR:bolt-omptarget-nvptx>)
 
       # Install bitcode library under the lib destination folder.
       install(FILES ${CMAKE_CURRENT_BINARY_DIR}/libomptarget-nvptx-sm_${sm}.bc DESTINATION "${OPENMP_INSTALL_LIBDIR}")

--- a/libomptarget/deviceRTLs/nvptx/test/lit.cfg
+++ b/libomptarget/deviceRTLs/nvptx/test/lit.cfg
@@ -45,6 +45,12 @@ config.test_flags = config.test_flags + " " + config.test_extra_flags
 prepend_library_path('LD_LIBRARY_PATH', config.library_dir, ":")
 prepend_library_path('LD_LIBRARY_PATH', config.omp_host_rtl_directory, ":")
 
+# Setup flags for BOLT.  If BOLT is not used, they are ignored.
+# Some tasking tests require larger stack size.
+config.environment['ABT_THREAD_STACKSIZE'] = "262144"
+# Sleep alleviates oversubscription overheads when -j is specified.
+config.environment['KMP_ABT_SCHED_SLEEP'] = "1"
+
 # Forbid fallback to host.
 config.environment["OMP_TARGET_OFFLOAD"] = "MANDATORY"
 

--- a/libomptarget/test/lit.cfg
+++ b/libomptarget/test/lit.cfg
@@ -64,6 +64,12 @@ else: # Unices
     append_dynamic_library_path('LD_LIBRARY_PATH', \
         config.omp_host_rtl_directory, ":")
 
+# Setup flags for BOLT.  If BOLT is not used, they are ignored.
+# Some tasking tests require larger stack size.
+config.environment['ABT_THREAD_STACKSIZE'] = "262144"
+# Sleep alleviates oversubscription overheads when -j is specified.
+config.environment['KMP_ABT_SCHED_SLEEP'] = "1"
+
 # substitutions
 # - for targets that exist in the system create the actual command.
 # - for valid targets that do not exist in the system, return false, so that the

--- a/tools/archer/tests/lit.cfg
+++ b/tools/archer/tests/lit.cfg
@@ -89,6 +89,12 @@ if config.has_tsan == True:
 if 'INTEL_LICENSE_FILE' in os.environ:
     config.environment['INTEL_LICENSE_FILE'] = os.environ['INTEL_LICENSE_FILE']
 
+# Setup flags for BOLT.  If BOLT is not used, they are ignored.
+# Some tasking tests require larger stack size.
+config.environment['ABT_THREAD_STACKSIZE'] = "262144"
+# Sleep alleviates oversubscription overheads when -j is specified.
+config.environment['KMP_ABT_SCHED_SLEEP'] = "1"
+
 # Race Tests
 config.substitutions.append(("%libarcher-compile-and-run-race", \
     "%libarcher-compile && %libarcher-run-race"))


### PR DESCRIPTION
`omptarget-nvptx` is used for offloading with a CUDA backend. This PR fixes it.
[EDIT] This PR also increases the default task stack size for testing.

Note that our Jenkins CI will include BOLT + CUDA (although there is no BOLT-specific optimization at present).