### PR TITLE
[2.x] substitute FileCheck even if OMPT is disabled

### DIFF
--- a/runtime/test/lit.cfg
+++ b/runtime/test/lit.cfg
@@ -137,8 +137,11 @@ config.substitutions.append(("%flags", config.test_flags))
 config.substitutions.append(("%python", '"%s"' % (sys.executable)))
 config.substitutions.append(("%not", config.test_not))
 
-if config.has_ompt:
+if config.test_filecheck != "":
+    # FileCheck is in any case necessary.
     config.substitutions.append(("FileCheck", "tee %%t.out | %s" % config.test_filecheck))
+
+if config.has_ompt:
     config.substitutions.append(("%sort-threads", "sort -n -s"))
     if config.operating_system == 'Windows':
         # No such environment variable on Windows.


### PR DESCRIPTION
The same as #82.